### PR TITLE
feat: advertise constraints in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,16 +30,53 @@ def load_requirements(*requirements_paths):
     """
     Load all requirements from the specified requirements files.
 
-    Returns:
-        list: Requirements file relative path strings
+    Requirements will include any constraints from files specified
+    with -c in the requirements files.
+    Returns a list of requirement strings.
     """
-    requirements = set()
+    # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why.
+
+    requirements = {}
+    constraint_files = set()
+
+    # groups "my-package-name<=x.y.z,..." into ("my-package-name", "<=x.y.z,...")
+    requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.]+)([<>=][^#\s]+)?")
+
+    def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
+        regex_match = requirement_line_regex.match(current_line)
+        if regex_match:
+            package = regex_match.group(1)
+            version_constraints = regex_match.group(2)
+            existing_version_constraints = current_requirements.get(package, None)
+            # it's fine to add constraints to an unconstrained package, but raise an error if there are already
+            # constraints in place
+            if existing_version_constraints and existing_version_constraints != version_constraints:
+                raise BaseException(f'Multiple constraint definitions found for {package}:'
+                                    f' "{existing_version_constraints}" and "{version_constraints}".'
+                                    f'Combine constraints into one location with {package}'
+                                    f'{existing_version_constraints},{version_constraints}.')
+            if add_if_not_present or package in current_requirements:
+                current_requirements[package] = version_constraints
+
+    # process .in files and store the path to any constraint files that are pulled in
     for path in requirements_paths:
-        requirements.update(
-            line.split('#')[0].strip() for line in open(path, encoding="utf8").readlines()
-            if is_requirement(line.strip())
-        )
-    return list(requirements)
+        with open(path) as reqs:
+            for line in reqs:
+                if is_requirement(line):
+                    add_version_constraint_or_raise(line, requirements, True)
+                if line and line.startswith('-c') and not line.startswith('-c http'):
+                    constraint_files.add(os.path.dirname(path) + '/' + line.split('#')[0].replace('-c', '').strip())
+
+    # process constraint files and add any new constraints found to existing requirements
+    for constraint_file in constraint_files:
+        with open(constraint_file) as reader:
+            for line in reader:
+                if is_requirement(line):
+                    add_version_constraint_or_raise(line, requirements, False)
+
+    # process back into list of pkg><=constraints strings
+    constrained_requirements = [f'{pkg}{version or ""}' for (pkg, version) in sorted(requirements.items())]
+    return constrained_requirements
 
 
 def is_requirement(line):
@@ -47,10 +84,12 @@ def is_requirement(line):
     Return True if the requirement line is a package requirement.
 
     Returns:
-        bool: True if the line is not blank, a comment, a URL, or
-              an included file
+        bool: True if the line is not blank, a comment,
+        a URL, or an included file
     """
-    return line and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
+    # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why
+
+    return line and line.strip() and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
 
 
 VERSION = get_version('commerce_coordinator', '__init__.py')

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def load_requirements(*requirements_paths):
 
     # process .in files and store the path to any constraint files that are pulled in
     for path in requirements_paths:
-        with open(path) as reqs:
+        with open(path, encoding='utf-8') as reqs:
             for line in reqs:
                 if is_requirement(line):
                     add_version_constraint_or_raise(line, requirements, True)
@@ -69,7 +69,7 @@ def load_requirements(*requirements_paths):
 
     # process constraint files and add any new constraints found to existing requirements
     for constraint_file in constraint_files:
-        with open(constraint_file) as reader:
+        with open(constraint_file, encoding='utf-8') as reader:
             for line in reader:
                 if is_requirement(line):
                     add_version_constraint_or_raise(line, requirements, False)


### PR DESCRIPTION
[ARCHBOM-1772](https://openedx.atlassian.net/browse/ARCHBOM-1772)
 Update setup.py to use constraint files when generating requirements files for packaging and distribution.
 PR generated automatically with Jenkins job cleanup-python-code. 

Result of running `python setup.py bdist_wheel` before applying fix (in .egg-info/requires.txt)\: 

edx-auth-backends
djangorestframework
mysqlclient
pytz
django-cors-headers
django-waffle
edx-django-utils
edx-drf-extensions
django-extensions
Django>=2.2
django-rest-swagger
edx-rest-api-client
edx-django-release-util

Result of running `python setup.py bdist_wheel` after applying fix (in .egg-info/requires.txt)\: 

Django>=2.2
django-cors-headers
django-extensions
django-rest-swagger
django-waffle
djangorestframework
edx-auth-backends
edx-django-release-util
edx-django-utils
edx-drf-extensions
edx-rest-api-client
mysqlclient
pytz