### PR TITLE
docs: Removed internal doc reference

### DIFF
--- a/docs/decisions/0003-internal-communication.rst
+++ b/docs/decisions/0003-internal-communication.rst
@@ -61,7 +61,7 @@ By default the connections between signals and their configured handlers can be 
 Rejected Alternatives
 *********************
 
-A lengthy investigation was undertaken to look at several options for making this system loosely coupled and easily extensible. For those with access, the results are here: https://docs.google.com/document/d/11PTYakKm7vR3BC_FYggemfRYZE8R3exfeHRDalasPcc#
+A lengthy investigation was undertaken to look at several options for making this system loosely coupled and easily extensible.
 
 Alternatives that were investigated and rejected:
 


### PR DESCRIPTION
The results of the Primer are adequately covered by the ADR, so removing the reference as the doc is not publicly accessible.