### PR TITLE
fix!: Replaced placeholder with the repo name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,17 +191,17 @@ github_docker_build:
 	docker build . -f Dockerfile --target newrelic -t openedx/repo_name:latest-newrelic
 
 github_docker_tag: github_docker_build
-	docker tag openedx/repo_name openedx/repo_name:${GITHUB_SHA}
-	docker tag openedx/repo_name:latest-newrelic openedx/repo_name:${GITHUB_SHA}-newrelic
+	docker tag openedx/commerce-coordinator openedx/repo_name:${GITHUB_SHA}
+	docker tag openedx/commerce-coordinator:latest-newrelic openedx/repo_name:${GITHUB_SHA}-newrelic
 
 github_docker_auth:
 	echo "$$DOCKERHUB_PASSWORD" | docker login -u "$$DOCKERHUB_USERNAME" --password-stdin
 
 github_docker_push: github_docker_tag github_docker_auth ## push to docker hub
-	docker push 'openedx/repo_name:latest'
-	docker push "openedx/repo_name:${GITHUB_SHA}"
-	docker push 'openedx/repo_name:latest-newrelic'
-	docker push "openedx/repo_name:${GITHUB_SHA}-newrelic"
+	docker push 'openedx/commerce-coordinator:latest'
+	docker push "openedx/commerce-coordinator:${GITHUB_SHA}"
+	docker push 'openedx/commerce-coordinator:latest-newrelic'
+	docker push "openedx/commerce-coordinator:${GITHUB_SHA}-newrelic"
 
 selfcheck: ## check that the Makefile is well-formed
 	@echo "The Makefile is well-formed."


### PR DESCRIPTION
**Description:** If/when we start publishing Docker images, we should use the actual repo name

**JIRA:** [[ARCHBOM-1963] IDA Cookiecutter: some Makefile targets do not substitute repo_name - JIRA](https://openedx.atlassian.net/browse/ARCHBOM-1963)

