### PR TITLE
refactor: Add decorator with receiver logs

### DIFF
--- a/commerce_coordinator/apps/core/signal_helpers.py
+++ b/commerce_coordinator/apps/core/signal_helpers.py
@@ -2,7 +2,6 @@
 Commerce Coordinator helper methods for ensuring consistency with Django signal handling.
 """
 import functools
-import inspect
 
 from django.dispatch import Signal
 
@@ -14,7 +13,7 @@ class CoordinatorSignal(Signal):
 
 def coordinator_receiver(logger):
     """
-    Return a decorated function with LMS log messages.
+    Return a decorated function with log messages.
     """
     def decorator(func):
         @functools.wraps(func)
@@ -23,8 +22,9 @@ def coordinator_receiver(logger):
             Wrapper function around the original function or method.
             """
             try:
+                # Django's signal dispatcher will give the sender as a keyword argument
                 sender = kwargs['sender']
-                logger.info(f"LMS {func.__name__} CALLED with sender '{sender}' and {kwargs}")
+                logger.info(f"{func.__name__} CALLED with sender '{sender}' and {kwargs}")
                 return func(*args, **kwargs)
             except Exception as e:
                 logger.exception(f"Something went wrong! Exception raised in {func.__name__} with error {repr(e)}")

--- a/commerce_coordinator/apps/demo_lms/signals.py
+++ b/commerce_coordinator/apps/demo_lms/signals.py
@@ -17,10 +17,14 @@ logger = logging.getLogger(__name__)
 #############################################################
 
 
-# Basic signal receiver to test out connecting signals and handlers via config
 @coordinator_receiver(logger)
-def test_receiver(sender, **kwargs):
-    pass
+def test_receiver(**kwargs):
+    """
+    Basic signal receiver to test out connecting signals and handlers via config.
+    Due to the coordinator_receiver decorator, this is an example of what we'll emit to the logs:
+    INFO 2394 [commerce_coordinator.apps.demo_lms.signals] test_receiver CALLED with sender '{sender}' and {kwargs}.
+    """
+    # This test can be modified accordingly to include more uses.
 
 
 # The rest of this file is related to the "Purchase Complete" demo
@@ -29,7 +33,7 @@ enroll_learner_signal = CoordinatorSignal()
 
 
 @coordinator_receiver(logger)
-def demo_purchase_complete_order_history(sender, **kwargs):
+def demo_purchase_complete_order_history(**kwargs):
     """
     This signal receiver would typically be in a separate app for just the Order History service, but is here for
     convenience. It kicks off a Celery task that would normally make an API to a 3rd party order history service.
@@ -38,7 +42,7 @@ def demo_purchase_complete_order_history(sender, **kwargs):
 
 
 @coordinator_receiver(logger)
-def demo_purchase_complete_send_confirmation_email(sender, **kwargs):
+def demo_purchase_complete_send_confirmation_email(**kwargs):
     """
     This signal receiver would typically be in a separate app for just the email service, but is here for
     convenience. It kicks off a Celery task that would normally make an API to a 3rd party email service to send
@@ -48,7 +52,7 @@ def demo_purchase_complete_send_confirmation_email(sender, **kwargs):
 
 
 @coordinator_receiver(logger)
-def demo_purchase_complete_enroll_in_course(sender, **kwargs):
+def demo_purchase_complete_enroll_in_course(**kwargs):
     """
     This signal receiver is one that legitimately belongs in LMS, it first off an enrollment event for each purchased
     course in an order. Any number of signal handlers could care about that, but in this demo only
@@ -60,7 +64,7 @@ def demo_purchase_complete_enroll_in_course(sender, **kwargs):
 
 
 @coordinator_receiver(logger)
-def demo_enroll_learner_in_course(sender, **kwargs):
+def demo_enroll_learner_in_course(**kwargs):
     """
     This signal receiver is one that legitimately belongs in LMS, it would kick off a Celery task to LMS to enroll a
     user in a single course.


### PR DESCRIPTION
[REV-2483](https://openedx.atlassian.net/browse/REV-2483).

A decorator should be created to unify and encapsulate the logging currently done in the demo receivers.

**This PR:**
- Adds a decorator with logs to replace the redundancy in LMS demo receivers.
- Removes logs that were repeated in the demo receivers.

**Testing instructions:**

Install `mySQL` in your local directory by running `brew install mysql` (if using homebrew)

Create virtual environment and launch Commerce Coordinator following the below steps:
1. `python3 -m venv .venv`
2. `source .venv/bin/activate`
3. `make requirements` or `CFLAGS='-D__x86_64__' make requirements` if you get "Unsupported architecture errors"
4. `python manage.py runserver localhost:8000 --settings=commerce_coordinator.settings.local`
5. Go to `http://localhost:8000/lms/test/` 
6. On terminal, should see logs for `test_receiver`

**Reviewers:**
- [x] @inventhouse 

**Merge checklist:**
- [x] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [x] Delete working branch (if not needed anymore)

