### PR TITLE
fix: add venv files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ htmlcov
 nosetests.xml
 unittests.xml
 
+# Virtual environment files
+.venv
+
 # PII annotation reports
 pii_report
 


### PR DESCRIPTION
Since my earlier update to the README specifies using venv for the virtual environment, I'm adding .venv to the gitignore file so nobody accidentally commits their virtual environment
