### PR TITLE
fix: [REV-2564] assign port 8140 to commerce-coordinator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV DJANGO_SETTINGS_MODULE commerce_coordinator.settings.production
 
-EXPOSE 8000
+EXPOSE 8140
 RUN useradd -m --shell /bin/false app
 
 WORKDIR /edx/app/commerce-coordinator

--- a/README.rst
+++ b/README.rst
@@ -58,10 +58,10 @@ Note: this setup process is temporary; we will be working on a Tutor plugin
   make dev.up.redis
 
   # run commerce-coordinator locally (run inside the venv)
-  python manage.py runserver localhost:8000 --settings=commerce_coordinator.settings.local
+  python manage.py runserver localhost:8140 --settings=commerce_coordinator.settings.local
 
   # You should see output ending with "Quit the server with CONTROL-C"
-  # In your browser, hit the URL: http://localhost:8000/demo_lms/test/
+  # In your browser, hit the URL: http://localhost:8140/demo_lms/test/
   # You should see JSON output indicating that two receivers were called, one successful, and one with exception/traceback information.
   # In the shell where the server is running you should see log output indicating that two test receivers were called with the sender argument "Something".
 
@@ -107,15 +107,15 @@ Local testing with Celery
   python manage.py celery
 
   # More test URLs you can hit in the browser or pipe through jq (https://stedolan.github.io/jq/) to make the output more readable:
-  ⫸ curl -s "http://localhost:8000/lms/test_celery_signal/" | jq '.'
+  ⫸ curl -s "http://localhost:8140/lms/test_celery_signal/" | jq '.'
  {
   "<function test_celery_signal_task at 0x10e17a9d0>": ""
  }
- ⫸ curl -s "http://localhost:8000/lms/test_celery_signal/" | jq '.'
+ ⫸ curl -s "http://localhost:8140/lms/test_celery_signal/" | jq '.'
  {
   "<function test_celery_signal_task at 0x10e17a9d0>": ""
  }
- ⫸ curl -s "http://localhost:8000/lms/demo_purchase_complete/" | jq '.'
+ ⫸ curl -s "http://localhost:8140/lms/demo_purchase_complete/" | jq '.'
  {
   "<function demo_purchase_complete_order_history at 0x10e18a430>": "",
   "<function demo_purchase_complete_send_confirmation_email at 0x10e18a5e0>": "",

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -5,7 +5,7 @@ import multiprocessing  # pylint: disable=unused-import
 
 preload_app = True
 timeout = 300
-bind = "0.0.0.0:8000"
+bind = "0.0.0.0:8140"
 
 workers = 2
 

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -208,7 +208,7 @@ BACKEND_SERVICE_EDX_OAUTH2_KEY = 'replace-me'
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'replace-me'
 
 JWT_AUTH = {
-    'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
+    'JWT_ISSUER': 'http://127.0.0.1:8140/oauth2',
     'JWT_ALGORITHM': 'HS256',
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_PAYLOAD_GET_USERNAME_HANDLER': lambda d: d.get('preferred_username'),

--- a/commerce_coordinator/settings/private.py.example
+++ b/commerce_coordinator/settings/private.py.example
@@ -1,5 +1,5 @@
 SOCIAL_AUTH_EDX_OAUTH2_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = 'replace-me'
-SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'http://127.0.0.1:8000/oauth'
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'http://127.0.0.1:8140/oauth'
 BACKEND_SERVICE_EDX_OAUTH2_KEY = 'commerce-coordinator-backend-service-key'
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'commerce-coordinator-backend-service-secret'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,11 @@ services:
     container_name: commerce-coordinator.app
     volumes:
       - .:/edx/app/commerce-coordinator/
-    command: bash -c 'while true; do python /edx/app/commerce-coordinator/manage.py runserver 0.0.0.0:8000; sleep 2; done'
+    command: bash -c 'while true; do python /edx/app/commerce-coordinator/manage.py runserver 0.0.0.0:8140; sleep 2; done'
     environment:
       DJANGO_SETTINGS_MODULE: commerce_coordinator.settings.devstack
     ports:
-      - "8000:8000" # TODO: change this to your port
+      - "8140:8140"
     networks:
       - devstack_default
     stdin_open: true

--- a/provision-commerce-coordinator.sh
+++ b/provision-commerce-coordinator.sh
@@ -1,5 +1,5 @@
 name="commerce-coordinator"
-port="8000"
+port="8140"
 
 docker-compose up -d --build
 


### PR DESCRIPTION
**Description:** Assigns port 8140 to commerce-coordinator.

**JIRA:** [Link to JIRA ticket](https://openedx.atlassian.net/browse/REV-2564)

**Dependencies:** N/A

**Merge deadline:** N/A

**Installation instructions:** N/A

**Testing instructions:**

Check output does not change after port re-assignment:

* http://localhost:8140/health/
* http://localhost:8140/demo_lms/test/

Before:

```
python manage.py runserver localhost:8000 --settings=commerce_coordinator.settings.local
```

After:

```
python manage.py runserver localhost:8140 --settings=commerce_coordinator.settings.local
```

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] ~~Version bumped~~
- [ ] ~~Changelog record added~~
- [X] Documentation updated (not only docstrings)
- [X] Commits are squashed

**Post merge:**
- [ ] ~~Create a tag~~
- [ ] ~~Check new version is pushed to PyPI after tag-triggered build is finished.~~
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** N/A
