### PR TITLE
fix: [REV-2564] s/repo_name/commerce-coordinator for github_docker_* Makefile directives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,12 +189,12 @@ db-shell: # Run the app shell as root, enter the app's database
 	docker attach commerce-coordinator.$*
 
 github_docker_build:
-	docker build . -f Dockerfile --target app -t openedx/repo_name
-	docker build . -f Dockerfile --target newrelic -t openedx/repo_name:latest-newrelic
+	docker build . -f Dockerfile --target app -t openedx/commerce-coordinator
+	docker build . -f Dockerfile --target newrelic -t openedx/commerce-coordinator:latest-newrelic
 
 github_docker_tag: github_docker_build
-	docker tag openedx/commerce-coordinator openedx/repo_name:${GITHUB_SHA}
-	docker tag openedx/commerce-coordinator:latest-newrelic openedx/repo_name:${GITHUB_SHA}-newrelic
+	docker tag openedx/commerce-coordinator openedx/commerce-coordinator:${GITHUB_SHA}
+	docker tag openedx/commerce-coordinator:latest-newrelic openedx/commerce-coordinator:${GITHUB_SHA}-newrelic
 
 github_docker_auth:
 	echo "$$DOCKERHUB_PASSWORD" | docker login -u "$$DOCKERHUB_USERNAME" --password-stdin


### PR DESCRIPTION
## Description

Fill in placeholder `repo_name` in Makefile to get Docker pushes working.

## Additional information

* Jira: [REV-2564](https://openedx.atlassian.net/browse/REV-2564)
* Research: [Confluence](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3342762040/REV-2564)