### PR TITLE
README: Clean up celery testing section (demo_lms name and duplicated step)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,15 +107,15 @@ Local testing with Celery
   python manage.py celery
 
   # More test URLs you can hit in the browser or pipe through jq (https://stedolan.github.io/jq/) to make the output more readable:
-  ⫸ curl -s "http://localhost:8140/lms/test_celery_signal/" | jq '.'
+  ⫸ curl -s "http://localhost:8140/demo_lms/test_celery_signal/" | jq '.'
  {
   "<function test_celery_signal_task at 0x10e17a9d0>": ""
  }
- ⫸ curl -s "http://localhost:8140/lms/test_celery_signal/" | jq '.'
+ ⫸ curl -s "http://localhost:8140/demo_lms/test_celery_signal/" | jq '.'
  {
   "<function test_celery_signal_task at 0x10e17a9d0>": ""
  }
- ⫸ curl -s "http://localhost:8140/lms/demo_purchase_complete/" | jq '.'
+ ⫸ curl -s "http://localhost:8140/demo_lms/demo_purchase_complete/" | jq '.'
  {
   "<function demo_purchase_complete_order_history at 0x10e18a430>": "",
   "<function demo_purchase_complete_send_confirmation_email at 0x10e18a5e0>": "",

--- a/README.rst
+++ b/README.rst
@@ -111,10 +111,6 @@ Local testing with Celery
  {
   "<function test_celery_signal_task at 0x10e17a9d0>": ""
  }
- ⫸ curl -s "http://localhost:8140/demo_lms/test_celery_signal/" | jq '.'
- {
-  "<function test_celery_signal_task at 0x10e17a9d0>": ""
- }
  ⫸ curl -s "http://localhost:8140/demo_lms/demo_purchase_complete/" | jq '.'
  {
   "<function demo_purchase_complete_order_history at 0x10e18a430>": "",


### PR DESCRIPTION
The celery testing steps in the README: 
-  still said 'lms' instead of 'demo_lms' (app was renamed [here](https://github.com/edx/commerce-coordinator/pull/12), but I missed this spot in the README)
- duplicated the test_celery_signal_task test

This PR fixes those two things. 

Note: it's known that the 'docs' check fails in this repo until we fix [REV-2615](https://openedx.atlassian.net/browse/REV-2615)