### PR TITLE
fix: [REV-2564] deprecated yaml.load(); use safe_load()

### DIFF
--- a/commerce_coordinator/settings/production.py
+++ b/commerce_coordinator/settings/production.py
@@ -25,7 +25,7 @@ FILE_STORAGE_BACKEND = {}
 if 'COMMERCE_COORDINATOR_CFG' in environ:
     CONFIG_FILE = get_env_setting('COMMERCE_COORDINATOR_CFG')
     with open(CONFIG_FILE, encoding='utf-8') as f:
-        config_from_yaml = yaml.load(f)
+        config_from_yaml = yaml.safe_load(f)
 
         # Remove the items that should be used to update dicts, and apply them separately rather
         # than pumping them into the local vars.


### PR DESCRIPTION

## Description

ArgoCD errors with:

```
  File "/edx/app/commerce-coordinator/commerce_coordinator/settings/production.py", line 28, in <module>
    config_from_yaml = yaml.load(f)
TypeError: load() missing 1 required positional argument: 'Loader'
```

This is because `yaml.load(f)` now requires a new parameter, or the use of `safe_load()`. See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation.

Solution copied from [Confluence](https://openedx.atlassian.net/wiki/spaces/SRE/pages/3298296133/Creating+a+New+Kubernetes+Django+Service#Some-notes-on-various-boilerplate-files).

## Testing Instructions

Successfully loaded project using `safe_load()` in ArgoCD development environment.

## Additional information

* Jira: [REV-2564](https://openedx.atlassian.net/browse/REV-2564)
* Research: [Confluence](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3342762040/REV-2564)