### PR TITLE
fix: [REV-2706] add local IP to ALLOWED_HOSTS for k8s health_check

### DIFF
--- a/commerce_coordinator/settings/production.py
+++ b/commerce_coordinator/settings/production.py
@@ -1,4 +1,5 @@
 from os import environ
+from socket import IPPROTO_TCP, getaddrinfo, gethostname
 
 import yaml
 
@@ -55,3 +56,6 @@ DB_OVERRIDES = dict(
 
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
+
+# add local IP to ALLOWED_HOSTS for k8s health_check
+ALLOWED_HOSTS += [addrinfo[4][0] for addrinfo in getaddrinfo(gethostname(), port=None, proto=IPPROTO_TCP)]


### PR DESCRIPTION
## Description

helm-charts django-ida uses a Kubernetes [`readinessProbe`](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes) to check whether the container has successfully started the Django app.

The `readinessProbe` checks for a successful GET response from the configured path in edx-internal's argocd/applications/commerce-coordinator YAML config.

The pod IP must be included in the Django app's [`ALLOWED_HOSTS`](https://docs.djangoproject.com/en/4.0/ref/settings/#allowed-hosts) settings for this check to succeed.

This commit uses [`socket.getaddrinfo`](https://docs.python.org/3/library/socket.html#socket.getaddrinfo) to get the IPv4 and IPv6 address of localhost and add it to `ALLOWED_HOSTS`.

## Additional information

* Jira: [REV-2706](https://openedx.atlassian.net/browse/REV-2706)
* Research: [Confluence](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3417112729/REV-2706)

## Testing instructions

* On local dev:
  * [ ] Modify development environment to restrict ALLOWED_HOSTS
  * [ ] Check accessing /health endpoint fails
  * [ ] Upload to Docker Hub on local branch
  * [ ] Check accessing /health endpoint succeeds
