### PR TITLE
docs: setup django for sphynx & bypass deprecated rST check

### DIFF
--- a/commerce_coordinator/urls.py
+++ b/commerce_coordinator/urls.py
@@ -2,17 +2,22 @@
 commerce-coordinator URL Configuration.
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.2/topics/http/urls/
+https://docs.djangoproject.com/en/2.2/topics/http/urls/
+
 Examples:
+
 Function views
     1. Add an import:  from my_app import views
     2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+
 Class-based views
     1. Add an import:  from other_app.views import Home
     2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+
 Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
+
 """
 
 import os

--- a/docs/commerce_coordinator.apps.api.rst
+++ b/docs/commerce_coordinator.apps.api.rst
@@ -1,0 +1,46 @@
+commerce\_coordinator.apps.api package
+======================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator.apps.api.tests
+   commerce_coordinator.apps.api.v1
+
+Submodules
+----------
+
+commerce\_coordinator.apps.api.models module
+--------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.api.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.api.serializers module
+-------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.api.serializers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.api.urls module
+------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.api.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.api
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.api.tests.rst
+++ b/docs/commerce_coordinator.apps.api.tests.rst
@@ -1,0 +1,10 @@
+commerce\_coordinator.apps.api.tests package
+============================================
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.api.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.api.v1.rst
+++ b/docs/commerce_coordinator.apps.api.v1.rst
@@ -1,0 +1,37 @@
+commerce\_coordinator.apps.api.v1 package
+=========================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator.apps.api.v1.tests
+
+Submodules
+----------
+
+commerce\_coordinator.apps.api.v1.urls module
+---------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.api.v1.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.api.v1.views module
+----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.api.v1.views
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.api.v1
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.api.v1.tests.rst
+++ b/docs/commerce_coordinator.apps.api.v1.tests.rst
@@ -1,0 +1,10 @@
+commerce\_coordinator.apps.api.v1.tests package
+===============================================
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.api.v1.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.core.migrations.rst
+++ b/docs/commerce_coordinator.apps.core.migrations.rst
@@ -1,0 +1,21 @@
+commerce\_coordinator.apps.core.migrations package
+==================================================
+
+Submodules
+----------
+
+commerce\_coordinator.apps.core.migrations.0001\_initial module
+---------------------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.migrations.0001_initial
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.core.migrations
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.core.rst
+++ b/docs/commerce_coordinator.apps.core.rst
@@ -1,0 +1,94 @@
+commerce\_coordinator.apps.core package
+=======================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator.apps.core.migrations
+   commerce_coordinator.apps.core.tests
+
+Submodules
+----------
+
+commerce\_coordinator.apps.core.admin module
+--------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.admin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.apps module
+-------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.apps
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.constants module
+------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.context\_processors module
+----------------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.context_processors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.models module
+---------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.signal\_helpers module
+------------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.signal_helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.signals module
+----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.signals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.tasks module
+--------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.views module
+--------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.views
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.core
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.core.tests.rst
+++ b/docs/commerce_coordinator.apps.core.tests.rst
@@ -1,0 +1,37 @@
+commerce\_coordinator.apps.core.tests package
+=============================================
+
+Submodules
+----------
+
+commerce\_coordinator.apps.core.tests.test\_context\_processors module
+----------------------------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.tests.test_context_processors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.tests.test\_models module
+---------------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.tests.test_models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.core.tests.test\_views module
+--------------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.core.tests.test_views
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.core.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.demo_lms.migrations.rst
+++ b/docs/commerce_coordinator.apps.demo_lms.migrations.rst
@@ -1,0 +1,10 @@
+commerce\_coordinator.apps.demo\_lms.migrations package
+=======================================================
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.migrations
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.demo_lms.rst
+++ b/docs/commerce_coordinator.apps.demo_lms.rst
@@ -1,0 +1,101 @@
+commerce\_coordinator.apps.demo\_lms package
+============================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator.apps.demo_lms.migrations
+
+Submodules
+----------
+
+commerce\_coordinator.apps.demo\_lms.admin module
+-------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.admin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.apps module
+------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.apps
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.filters module
+---------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.filters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.models module
+--------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.pipeline module
+----------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.pipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.signals module
+---------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.signals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.tasks module
+-------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.tests module
+-------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.urls module
+------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.demo\_lms.views module
+-------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms.views
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.demo_lms
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.orders.migrations.rst
+++ b/docs/commerce_coordinator.apps.orders.migrations.rst
@@ -1,0 +1,10 @@
+commerce\_coordinator.apps.orders.migrations package
+====================================================
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.orders.migrations
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.orders.rst
+++ b/docs/commerce_coordinator.apps.orders.rst
@@ -1,0 +1,77 @@
+commerce\_coordinator.apps.orders package
+=========================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator.apps.orders.migrations
+
+Submodules
+----------
+
+commerce\_coordinator.apps.orders.admin module
+----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.orders.admin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.orders.apps module
+---------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.orders.apps
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.orders.clients module
+------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.orders.clients
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.orders.models module
+-----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.orders.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.orders.tests module
+----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.orders.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.orders.urls module
+---------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.orders.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.orders.views module
+----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.orders.views
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.orders
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.rst
+++ b/docs/commerce_coordinator.apps.rst
@@ -1,0 +1,21 @@
+commerce\_coordinator.apps package
+==================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator.apps.api
+   commerce_coordinator.apps.core
+   commerce_coordinator.apps.demo_lms
+   commerce_coordinator.apps.orders
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.rst
+++ b/docs/commerce_coordinator.rst
@@ -1,0 +1,54 @@
+commerce\_coordinator package
+=============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator.apps
+   commerce_coordinator.settings
+
+Submodules
+----------
+
+commerce\_coordinator.celery\_app module
+----------------------------------------
+
+.. automodule:: commerce_coordinator.celery_app
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.docker\_gunicorn\_configuration module
+------------------------------------------------------------
+
+.. automodule:: commerce_coordinator.docker_gunicorn_configuration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.urls module
+---------------------------------
+
+.. automodule:: commerce_coordinator.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.wsgi module
+---------------------------------
+
+.. automodule:: commerce_coordinator.wsgi
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.settings.rst
+++ b/docs/commerce_coordinator.settings.rst
@@ -1,0 +1,61 @@
+commerce\_coordinator.settings package
+======================================
+
+Submodules
+----------
+
+commerce\_coordinator.settings.base module
+------------------------------------------
+
+.. automodule:: commerce_coordinator.settings.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.settings.devstack module
+----------------------------------------------
+
+.. automodule:: commerce_coordinator.settings.devstack
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.settings.local module
+-------------------------------------------
+
+.. automodule:: commerce_coordinator.settings.local
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.settings.production module
+------------------------------------------------
+
+.. automodule:: commerce_coordinator.settings.production
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.settings.test module
+------------------------------------------
+
+.. automodule:: commerce_coordinator.settings.test
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.settings.utils module
+-------------------------------------------
+
+.. automodule:: commerce_coordinator.settings.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.settings
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,12 @@ VERSION = get_version('../commerce_coordinator', '__init__.py')
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+# Setup Django so imports are available for docs
+sys.path.insert(0, os.path.abspath('..'))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'commerce_coordinator.settings.test')
+import django
+django.setup()
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+commerce_coordinator
+====================
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
     rm -f docs/modules.rst
     make -e -C docs clean
     make -e -C docs html
-    python setup.py check --restructuredtext --strict
+    python setup.py check --restructuredtext
 
 [testenv:quality]
 whitelist_externals = 


### PR DESCRIPTION
## Description

This PR fixes 2 errors in the build process:

### `AppRegistryNotReady`

The docs GitHub action is currently failing due to an error like:

```
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```

This PR fixes that error by running `django.setup()` to bootstrap all the classes required so the automatic documentation tool `autodoc` can do its job.

### rST duplicate implicit target name

After that error is fixed, the GitHub action fails due to an error like:

```
docs run-test: commands[5] | python setup.py check --restructuredtext --strict
...
warning: check: Duplicate implicit target name: "...".
...
ERROR: InvocationError for command /home/runner/work/commerce-coordinator/commerce-coordinator/.tox/docs/bin/python setup.py check --restructuredtext --strict (exited with code 1)
```

This docs test lints all rST in the repository (as opposed to only the generated rST in the `docs` folder). Unfortunately, it:
* Has a bug which elevates INFO-level lint messages to WARN-level lint messages.
* Will be eventually deprecated because it is part of the `distutils` library.

This PR removes `--strict` from the command invocation, thus printing out the lint results but not making the build red because of any errors.

[REV-2766](https://2u-internal.atlassian.net/browse/REV-2766) has been filed to consider options for restoring this check.

## Additional information

* Jira: [REV-2615](https://2u-internal.atlassian.net/browse/REV-2615)
* Follow-up ticket: [REV-2766](https://2u-internal.atlassian.net/browse/REV-2766)

## Testing information

* On local:
  * [X] Generate same error by running `make html`
  * [X] Apply fix and verify `make html` no longer errors
* On GitHub:
  * [X] Check docs check now passes