### PR TITLE
fix: docs strict check errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,9 +20,13 @@ Unreleased
 [0.2.0] - 2021-10-04
 ********************
 
+.. _added_0.2.0:
+
 Added
 =====
 Added Support for Django40
+
+.. _dropped_0.2.0:
 
 Dropped
 =======
@@ -30,6 +34,8 @@ Dropped support for Django22, 30 and 31
 
 [0.1.0] - 2021-10-04
 ********************
+
+.. _added_0.1.0:
 
 Added
 =====

--- a/README.rst
+++ b/README.rst
@@ -140,8 +140,8 @@ So far, this is very preliminary work proving out our ability to confirm and con
 
 Note: We expect that the system will be easier to reason about if signals are only confined to the primary IDA; other environments (e.g. Celery workers) could call API endpoints to trigger workflows if necessary.
 
-How To Contribute
-*****************
+Contributing
+************
 
 Contributions are very welcome.
 Please read `How To Contribute <https://github.com/edx/edx-platform/blob/main/CONTRIBUTING.rst>`_ for details.  Even though they were written with ``edx-platform`` in mind, the guidelines should be followed for all Open edX projects.
@@ -155,8 +155,8 @@ Reporting Security Issues
 
 Please do not report security issues in public. Please email security@edx.org.
 
-Getting Help
-************
+Getting Assistance
+******************
 
 If you're having trouble, we have discussion forums at https://discuss.openedx.org where you can connect with others in the community.
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Initial Setup: steps and confirmation
 
 Note: this setup process is temporary; we will be working on a Tutor plugin
 
-.. code-block::
+.. code-block:: shell
 
   # Clone the repository
   git clone git@github.com:edx/commerce-coordinator.git
@@ -74,7 +74,7 @@ Note: this setup process is temporary; we will be working on a Tutor plugin
 
 Every time you develop something in this repo
 =============================================
-.. code-block::
+.. code-block:: shell
 
   # Grab the latest code
   git checkout main
@@ -104,7 +104,7 @@ Every time you develop something in this repo
 
 Local testing with Celery
 =========================
-.. code-block::
+.. code-block:: shell
 
   # Start redis in devstack from your local devstack directory
   make dev.up.redis

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
     rm -f docs/modules.rst
     make -e -C docs clean
     make -e -C docs html
-    python setup.py check --restructuredtext
+    python setup.py check --restructuredtext --strict
 
 [testenv:quality]
 whitelist_externals = 


### PR DESCRIPTION
## Description

This PR is an attempt to fix the `python setup.py check --restructuredtext --strict` errors.

The error is:

```
(cc) commerce-coordinator % python setup.py check --restructuredtext --strict 
running check
warning: check: Duplicate implicit target name: "added".
```

The warning refers to [line 25](https://github.com/edx/commerce-coordinator/pull/34/files#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR25) and [line 40](https://github.com/edx/commerce-coordinator/pull/34/files#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR40) of CHANGELOG.rst having the same implicit target name.

Adding an explicit target name to dedup does not appear to squash the error.

This PR assumes we must avoid deviating from the [standard used by CHANGELOG.rst](https://keepachangelog.com/).

## Additional information

This PR was made as a part of ongoing discussions regarding the best way to do `python setup.py check --restructuredtext --strict` org-wide.

* See:
  * https://github.com/openedx/edx-cookiecutters/pull/204
  * https://github.com/edx/commerce-coordinator/pull/33

## Testing instructions

* On local:
  * [ ] Run `make requirements`
  * [ ] Run `make doc_requirements`
  * [ ] Run `python setup.py check --restructuredtext --strict` and see no errors