### PR TITLE
chore: merge updates from edx-cookiecutter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,3 @@ CMD gunicorn --workers=2 --name commerce-coordinator -c /edx/app/commerce-coordi
 # This line is after the requirements so that changes to the code will not
 # bust the image cache
 COPY . /edx/app/commerce-coordinator
-
-FROM app as newrelic
-RUN pip install newrelic
-CMD newrelic-admin run-program gunicorn --workers=2 --name commerce-coordinator -c /edx/app/commerce-coordinator/commerce_coordinator/docker_gunicorn_configuration.py --log-file - --max-requests=1000 commerce_coordinator.wsgi:application

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -58,8 +58,11 @@ INSTALLED_APPS += PROJECT_APPS
 MIDDLEWARE = (
     # Resets RequestCache utility for added safety.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
-    # Enables monitoring utility for writing custom metrics.
-    'edx_django_utils.monitoring.middleware.MonitoringCustomMetricsMiddleware',
+    # Monitoring middleware should be immediately after RequestCacheMiddleware
+    'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',  # python and django version
+    'edx_django_utils.monitoring.CookieMonitoringMiddleware',  # cookie names (compliance) and sizes
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',  # support accumulate & increment
+    'edx_django_utils.monitoring.MonitoringMemoryMiddleware',  # memory usage
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
## Description

Work in commerce-coordinator was blocked because of missing commits from edx-cookiecutter.

Review other commits to edx-cookiecutter since commerce-coordinatore repo creation using `git log --patch --stat --reverse --oneline --no-merges --invert-grep --since="2021-10-01" --grep "^chore:"`

Found and applied https://github.com/openedx/edx-cookiecutters/commit/8dfdeec9b84e71cc5255bc4f6e1dbceb1e7750d7 and https://github.com/openedx/edx-cookiecutters/commit/912c5ff10492bee055b9ad4d50d9cad649b4a1fc.

## Testing Instructions

* On dev:
  * [X] Able to reach /health and /orders endpoints.