### PR TITLE
fix: update RequestMetricsMiddleware to RequestCustomAttributesMiddleware

### DIFF
--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -77,7 +77,7 @@ MIDDLEWARE = (
     # Enables force_django_cache_miss functionality for TieredCache.
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     # Outputs monitoring metrics for a request.
-    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.middleware.RequestCustomAttributesMiddleware',
     # Ensures proper DRF permissions in support of JWTs
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 )


### PR DESCRIPTION
## Description

RequestMetricsMiddleware has been renamed to RequestCustomAttributesMiddleware.

This PR squashes this warning:

    .virtualenvs/cc/lib/python3.8/site-packages/edx_rest_framework_extensions/middleware.py:198: DeprecationWarning: Use 'RequestCustomAttributesMiddleware' in place of 'RequestMetricsMiddleware'.

## Additional Information

* See: [edx-drf-extensions docs](https://edx-drf-extensions.readthedocs.io/en/7.0.1/middleware.html#edx_rest_framework_extensions.middleware.RequestMetricsMiddleware)