### PR TITLE
feat: use PyMemcacheCache caching backend in production

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,13 +14,13 @@ billiard==3.6.4.0
     # via celery
 celery[redis]==5.2.7
     # via -r requirements/base.in
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
@@ -41,7 +41,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==37.0.2
+cryptography==37.0.4
     # via
     #   pyjwt
     #   social-auth-core
@@ -51,7 +51,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.13
     # via redis
-django==3.2.13
+django==3.2.14
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -113,9 +113,9 @@ kombu==5.2.4
     # via celery
 markupsafe==2.1.1
     # via jinja2
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via -r requirements/base.in
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via edx-django-utils
 oauthlib==3.2.0
     # via
@@ -129,13 +129,13 @@ packaging==21.3
     # via redis
 pbr==5.9.0
     # via stevedore
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via click-repl
 psutil==5.9.1
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -164,9 +164,9 @@ pytz==2022.1
     #   djangorestframework
 pyyaml==6.0
     # via edx-django-release-util
-redis==4.3.3
+redis==4.3.4
     # via celery
-requests==2.28.0
+requests==2.28.1
     # via
     #   coreapi
     #   edx-drf-extensions

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
@@ -30,7 +30,7 @@ py==1.11.0
     # via tox
 pyparsing==3.0.9
     # via packaging
-requests==2.28.0
+requests==2.28.1
     # via codecov
 six==1.16.0
     # via
@@ -38,9 +38,9 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.25.0
+tox==3.25.1
     # via -r requirements/ci.in
 urllib3==1.26.9
     # via requests
-virtualenv==20.14.1
+virtualenv==20.15.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,24 +29,28 @@ billiard==3.6.4.0
     # via
     #   -r requirements/validation.txt
     #   celery
-bleach==5.0.0
+bleach==5.0.1
     # via
     #   -r requirements/validation.txt
     #   readme-renderer
+build==0.8.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
 celery[redis]==5.2.7
     # via -r requirements/validation.txt
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -r requirements/validation.txt
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   -r requirements/validation.txt
     #   cryptography
     #   pynacl
-chardet==4.0.0
+chardet==5.0.0
     # via diff-cover
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -r requirements/validation.txt
     #   requests
@@ -100,7 +104,7 @@ coverage[toml]==6.4.1
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==37.0.2
+cryptography==37.0.4
     # via
     #   -r requirements/validation.txt
     #   pyjwt
@@ -114,13 +118,13 @@ deprecated==1.2.13
     # via
     #   -r requirements/validation.txt
     #   redis
-diff-cover==6.5.0
+diff-cover==6.5.1
     # via -r requirements/dev.in
 dill==0.3.5.1
     # via
     #   -r requirements/validation.txt
     #   pylint
-django==3.2.13
+django==3.2.14
     # via
     #   -r requirements/validation.txt
     #   django-cors-headers
@@ -141,7 +145,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
-django-debug-toolbar==3.4.0
+django-debug-toolbar==3.5.0
     # via
     #   -r requirements/dev.in
     #   -r requirements/validation.txt
@@ -162,7 +166,7 @@ djangorestframework==3.13.1
     #   django-rest-swagger
     #   drf-jwt
     #   edx-drf-extensions
-docutils==0.18.1
+docutils==0.19
     # via
     #   -r requirements/validation.txt
     #   readme-renderer
@@ -199,7 +203,7 @@ idna==3.3
     # via
     #   -r requirements/validation.txt
     #   requests
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   -r requirements/validation.txt
     #   keyring
@@ -244,9 +248,9 @@ mccabe==0.7.0
     #   pylint
 mock==4.0.3
     # via -r requirements/validation.txt
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via -r requirements/validation.txt
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -263,7 +267,9 @@ openedx-filters==0.7.0
     # via -r requirements/validation.txt
 packaging==21.3
     # via
+    #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
+    #   build
     #   pytest
     #   redis
 path==16.4.0
@@ -275,8 +281,8 @@ pbr==5.9.0
 pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
-    #   pip-tools
-pip-tools==6.6.2
+    #   build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.txt
 pkginfo==1.8.3
     # via
@@ -293,7 +299,7 @@ pluggy==1.0.0
     #   pytest
 polib==1.1.1
     # via edx-i18n-tools
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via
     #   -r requirements/validation.txt
     #   click-repl
@@ -311,7 +317,7 @@ pycparser==2.21
     # via
     #   -r requirements/validation.txt
     #   cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via
     #   -r requirements/validation.txt
     #   pyjwkest
@@ -335,7 +341,7 @@ pyjwt[crypto]==2.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.14.2
+pylint==2.14.4
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -365,6 +371,7 @@ pynacl==1.5.0
     #   edx-django-utils
 pyparsing==3.0.9
     # via
+    #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
     #   packaging
 pytest==7.1.2
@@ -404,11 +411,11 @@ readme-renderer==35.0
     # via
     #   -r requirements/validation.txt
     #   twine
-redis==4.3.3
+redis==4.3.4
     # via
     #   -r requirements/validation.txt
     #   celery
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/validation.txt
     #   coreapi
@@ -492,17 +499,18 @@ tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
+    #   build
     #   coverage
     #   pep517
     #   pylint
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via
     #   -r requirements/validation.txt
     #   pylint
 twine==4.0.1
     # via -r requirements/validation.txt
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/validation.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -27,26 +27,26 @@ attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.10.2
+babel==2.10.3
     # via sphinx
 billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
     #   celery
-bleach==5.0.0
+bleach==5.0.1
     # via readme-renderer
 celery[redis]==5.2.7
     # via -r requirements/test.txt
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -r requirements/test.txt
     #   requests
@@ -94,7 +94,7 @@ coverage[toml]==6.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==37.0.2
+cryptography==37.0.4
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -112,7 +112,7 @@ dill==0.3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
-django==3.2.13
+django==3.2.14
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -190,9 +190,9 @@ idna==3.3
     # via
     #   -r requirements/test.txt
     #   requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via sphinx
 iniconfig==1.1.1
     # via
@@ -230,9 +230,9 @@ mccabe==0.7.0
     #   pylint
 mock==4.0.3
     # via -r requirements/test.txt
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via -r requirements/test.txt
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -265,7 +265,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via
     #   -r requirements/test.txt
     #   click-repl
@@ -281,7 +281,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -302,7 +302,7 @@ pyjwt[crypto]==2.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.14.2
+pylint==2.14.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -369,11 +369,11 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==35.0
     # via -r requirements/doc.in
-redis==4.3.3
+redis==4.3.4
     # via
     #   -r requirements/test.txt
     #   celery
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/test.txt
     #   coreapi
@@ -426,7 +426,7 @@ social-auth-core==4.3.0
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sphinx==5.0.1
+sphinx==5.0.2
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -463,11 +463,11 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/test.txt
     #   astroid

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,14 +4,22 @@
 #
 #    make upgrade
 #
+build==0.8.0
+    # via pip-tools
 click==8.1.3
     # via pip-tools
+packaging==21.3
+    # via build
 pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
+    # via build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.in
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.1
-    # via pep517
+    # via
+    #   build
+    #   pep517
 wheel==0.37.1
     # via pip-tools
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.37.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.1.2
     # via -r requirements/pip.in
-setuptools==62.4.0
+setuptools==63.1.0
     # via -r requirements/pip.in

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -4,5 +4,5 @@
 gevent
 gunicorn
 mysqlclient
-python-memcached
+pymemcache
 PyYAML>=5.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -22,16 +22,16 @@ billiard==3.6.4.0
     #   celery
 celery[redis]==5.2.7
     # via -r requirements/base.txt
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -r requirements/base.txt
     #   requests
@@ -64,7 +64,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-cryptography==37.0.2
+cryptography==37.0.4
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -78,7 +78,7 @@ deprecated==1.2.13
     # via
     #   -r requirements/base.txt
     #   redis
-django==3.2.13
+django==3.2.14
     # via
     #   -r requirements/base.txt
     #   django-cors-headers
@@ -163,11 +163,11 @@ markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   jinja2
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -190,7 +190,7 @@ pbr==5.9.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -202,7 +202,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -218,6 +218,8 @@ pyjwt[crypto]==2.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
+pymemcache==3.5.2
+    # via -r requirements/production.in
 pymongo==3.12.3
     # via
     #   -r requirements/base.txt
@@ -234,8 +236,6 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-python-memcached==1.59
-    # via -r requirements/production.in
 python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
@@ -251,11 +251,11 @@ pyyaml==6.0
     #   -r requirements/base.txt
     #   -r requirements/production.in
     #   edx-django-release-util
-redis==4.3.3
+redis==4.3.4
     # via
     #   -r requirements/base.txt
     #   celery
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/base.txt
     #   coreapi
@@ -285,8 +285,8 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   pyjwkest
+    #   pymemcache
     #   python-dateutil
-    #   python-memcached
 slumber==0.7.1
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -29,20 +29,20 @@ billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
     #   celery
-bleach==5.0.0
+bleach==5.0.1
     # via readme-renderer
 celery[redis]==5.2.7
     # via -r requirements/test.txt
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -r requirements/test.txt
     #   requests
@@ -92,7 +92,7 @@ coverage[toml]==6.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==37.0.2
+cryptography==37.0.4
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -110,7 +110,7 @@ dill==0.3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
-django==3.2.13
+django==3.2.14
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -131,7 +131,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-django-debug-toolbar==3.4.0
+django-debug-toolbar==3.5.0
     # via -r requirements/quality.in
 django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
@@ -150,7 +150,7 @@ djangorestframework==3.13.1
     #   django-rest-swagger
     #   drf-jwt
     #   edx-drf-extensions
-docutils==0.18.1
+docutils==0.19
     # via readme-renderer
 drf-jwt==1.19.2
     # via
@@ -185,7 +185,7 @@ idna==3.3
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   keyring
     #   twine
@@ -227,9 +227,9 @@ mccabe==0.7.0
     #   pylint
 mock==4.0.3
     # via -r requirements/test.txt
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via -r requirements/test.txt
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -263,7 +263,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via
     #   -r requirements/test.txt
     #   click-repl
@@ -281,7 +281,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -303,7 +303,7 @@ pyjwt[crypto]==2.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.14.2
+pylint==2.14.4
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -369,11 +369,11 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==35.0
     # via twine
-redis==4.3.3
+redis==4.3.4
     # via
     #   -r requirements/test.txt
     #   celery
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/test.txt
     #   coreapi
@@ -451,13 +451,13 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via
     #   -r requirements/test.txt
     #   pylint
 twine==4.0.1
     # via -r requirements/quality.in
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/test.txt
     #   astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -28,16 +28,16 @@ billiard==3.6.4.0
     #   celery
 celery[redis]==5.2.7
     # via -r requirements/base.txt
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -r requirements/base.txt
     #   requests
@@ -83,7 +83,7 @@ coverage[toml]==6.4.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==37.0.2
+cryptography==37.0.4
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -192,9 +192,9 @@ mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.in
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via -r requirements/base.txt
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -222,7 +222,7 @@ platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -236,7 +236,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -252,7 +252,7 @@ pyjwt[crypto]==2.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.14.2
+pylint==2.14.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -307,11 +307,11 @@ pyyaml==6.0
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-release-util
-redis==4.3.3
+redis==4.3.4
     # via
     #   -r requirements/base.txt
     #   celery
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/base.txt
     #   coreapi
@@ -374,9 +374,9 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via pylint
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -35,7 +35,7 @@ billiard==3.6.4.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-bleach==5.0.0
+bleach==5.0.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -43,18 +43,18 @@ celery[redis]==5.2.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -116,7 +116,7 @@ coverage[toml]==6.4.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==37.0.2
+cryptography==37.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -138,7 +138,7 @@ dill==0.3.5.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-django==3.2.13
+django==3.2.14
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -162,7 +162,7 @@ django-crum==0.7.9
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-django-debug-toolbar==3.4.0
+django-debug-toolbar==3.5.0
     # via -r requirements/quality.txt
 django-dynamic-fixture==3.1.2
     # via
@@ -189,7 +189,7 @@ djangorestframework==3.13.1
     #   django-rest-swagger
     #   drf-jwt
     #   edx-drf-extensions
-docutils==0.18.1
+docutils==0.19
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -239,7 +239,7 @@ idna==3.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -293,11 +293,11 @@ mock==4.0.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -342,7 +342,7 @@ pluggy==1.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -364,7 +364,7 @@ pycparser==2.21
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -390,7 +390,7 @@ pyjwt[crypto]==2.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.14.2
+pylint==2.14.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -475,12 +475,12 @@ readme-renderer==35.0
     # via
     #   -r requirements/quality.txt
     #   twine
-redis==4.3.3
+redis==4.3.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -578,14 +578,14 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
 twine==4.0.1
     # via -r requirements/quality.txt
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
## Description

Per the [Django 3.2 docs](https://docs.djangoproject.com/en/3.2/topics/cache/#memcached):

> The MemcachedCache backend is deprecated as python-memcached has some problems and seems to be unmaintained. Use PyMemcacheCache or PyLibMCCache instead.

This PR replaces `python-memcached` with `pymemcache` in requirements/production.in.

## Additional Information

* See also: [edx-internal#6827](https://github.com/edx/edx-internal/pull/6827/files#diff-a44b696bee0711fbaeb892add35abf3d93ac3ed179d56c17320b7bddf624e460R36), which adds the following to Django settings in production:
    ```
    CACHES:
        default:
            BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
            KEY_PREFIX: commerce-coordinator
            LOCATION:
                - <host>:<port>
                - <host>:<port>
    ```