### PR TITLE
docs: Added ADR-5 for API decoupling proxies and other updates

### DIFF
--- a/docs/decisions/0001-coodinator-design.rst
+++ b/docs/decisions/0001-coodinator-design.rst
@@ -5,12 +5,18 @@
 Status
 ******
 
-**Draft**
+**Accepted**
 
 Context
 *******
 
 edX's monolithic Ecommerce Service was meant to be a full-featured product catalog, discounting, and order management service and has grown in complexity for many years until it has become very hard to maintain, let alone evolve.  In that time, more and better hosted services have become available for solving many of these problems, and complex use cases have evolved that make flexibility for Open edX operators vital.
+
+To avoid simply rebuilding another complicated, hard to change system, Commerce Coordinator design and implementation is guided by three main principles:
+
+- Simplicity: keep the design simple and the code clean.  Always start simple and iterate or extend if required.
+- Extensibility: the highly modular architecture helps keep solutions simple and allows iterating them; any necessary complexity can be encapsulated in plugins or pushed to external systems as much as possible.
+- Integration rather than function: both the core and the plugins should strive to do *less*; plugins should simply communicate with a specific external system and integrate with other plugins to bring the data and functionality of those systems together.
 
 
 Decisions

--- a/docs/decisions/0002-asynchronous-processing.rst
+++ b/docs/decisions/0002-asynchronous-processing.rst
@@ -5,7 +5,7 @@
 Status
 ******
 
-**Draft**
+**Accepted**
 
 Context
 *******

--- a/docs/decisions/0003-internal-communication.rst
+++ b/docs/decisions/0003-internal-communication.rst
@@ -5,7 +5,7 @@
 Status
 ******
 
-**Draft**
+**Accepted**
 
 
 Context

--- a/docs/decisions/0004-openedx-filters-for-close-communication.rst
+++ b/docs/decisions/0004-openedx-filters-for-close-communication.rst
@@ -5,12 +5,7 @@
 Status
 ******
 
-**Draft**
-
-.. Standard statuses
-    - **Draft** if the decision is still preliminary and in experimental phase
-    - **Accepted** *(date)* once it is agreed upon
-    - **Superseded** *(date)* with a reference to its replacement if a later ADR changes or reverses the decision
+**Accepted**
 
 Context
 *******

--- a/docs/decisions/0005-api-decoupling-proxies.rst
+++ b/docs/decisions/0005-api-decoupling-proxies.rst
@@ -1,0 +1,71 @@
+##########################
+0005 API Decoupling Proxy
+##########################
+
+Status
+******
+
+**Draft**
+
+Context
+*******
+
+We are working on the first step of the `overall deprecation plan <https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839#roadmap-3>`__:
+- Decouple legacy ecommerce service from other systems by routing data through the Coordinator.
+- Integrate Coordinator with new back-end systems and migrate processes as piecemeal as we can.
+- Once nothing relies on the legacy integrations anymore, we can fully retire legacy ecommerce.
+
+This "decoupling" work is important for enabling smooth, risk-managed, migration to new backend services not only for edX.org's installation, but as a ramp for other Open edX deployments implementing their own Commerce Coordinator integrations as well.
+
+To start decoupling the legacy ecommerce service from other services and micro-frontends we’re building thin shims for the Coordiator and routing requests there and, for now, these shims will basically call the relevant legacy APIs.
+
+Decision
+********
+
+Use a proxy pattern when interposing Coordinator in front of other services' APIs, particularly while decoupling the legacy ecommerce service.
+
+Note: Commerce Coordinator should be used to facilitate coordination, especially _between_ systems involved in the order management workflow. It does not have to be added into the middle of every step.
+
+Consequences
+************
+
+- Proxies can be brittle.
+- Could consider caching at times but beware of the added complexity vs. how often the cached value might be used.
+- Proxy pattern is primarily for, but not necessarily limited to, decoupling; there could be cases where this is the best pattern for routing and / or data transformation between systems.
+
+When and How to Use a Decoupling Proxy
+**************************************
+
+*(( TODO: when to use decoupling proxy ))*
+
+Managing Decoupling and Migration
+=================================
+
+- Build a pair of decoupling plugins for Coordinator
+- Add a waffle flag _in the legacy system_ to manage the transition to routing through the Coordinator
+- Test and roll-out Coordinator routing
+- Write a Coordinator back-end plugin for the new system
+- Add a Coordinator waffle flag
+- Test and roll-out the new plugin / configuration
+
+Author Concerns
+***************
+
+- Although directly proxying APIs is not generally intended to be a long-term solution, transition periods can stretch on longer than expected.  However, long-term reliance on the legacy ecommerce service is, in itself, a much greater concern than continuing to proxy any of its APIs.
+- Decoupling the legacy ecommerce service by interposing the Coordinator could be misunderstood to mean that everything should continue to be routed through it.  The Coordinator does not have to broker all-the-things; systems-of-record can vend or host their own ui/frontends and other things that don't need to interact with anything else.
+
+Alternatives Considered
+***********************
+
+Replication of business objects or functionality
+================================================
+
+- This would add significant complexity, requiring replication and synchronization processes for each type of data being duplicated.
+- One argument for replication is to guard against failure in the source-of-truth legacy system; currently the legacy system is already a potential point-of-failure, it is the Coordinator that is a new possible failure point and obviously replication doesn't help with that.
+
+Caching of results
+==================
+
+- Likely to be better than full replication, but it would also add significant complexity, requiring storage of the responses or response data and invalidation or refresh policies.
+- Many APIs/responses have a low likelihood of reuse, for example caching an individual learner's order history.
+- If an API *seems* like a good candidate for caching, test and profile first; err on the side of simplicity.


### PR DESCRIPTION
**Description:**
- Added ADR-5 describing our decision to use a proxy pattern for decoupling legacy ecommerce APIs
- Added some more background about Commerce Coordinator design goals to ADR-1
- Updated the status of all the ADRs from "Draft" to "Accepted"

**JIRA:** [[REV-2703] Hoist Order History: proxy design ADR - 2U Internal Jira](https://2u-internal.atlassian.net/browse/REV-2703)
