### PR TITLE
feat: add django app edx_django_utils.user for app-permissions

### DIFF
--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = (
 THIRD_PARTY_APPS = (
     'corsheaders',
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens
+    'edx_django_utils.user',
     'rest_framework',
     'rest_framework_swagger',
     'social_django',


### PR DESCRIPTION
## Description

This PR adds Django application `edx_django_utils.user` to the `INSTALLED_APPS` so that commerce-coordinator supports more robust, programmatic user management.

In particular, the `edx_django_utils.user` app allows tools like app-permissions to manage Django users and groups in commerce-coordinator.

This is required so tools can programmatically manage the users and groups that can, e.g. access the Django admin dashboard in commerce-coordinator.

## Additional Information

* Confluence: [Instructions](https://2u-internal.atlassian.net/wiki/spaces/SRE/pages/19237986/How+To+Onboard+a+Django+Service+to+App+Permissions)

## Testing Information

Tested locally by running `python manage.py` and verifying the addition of management commands:

```
[user]
    manage_group
    manage_user
```