### PR TITLE
feat: [REV-2847] add ecommerce/redeem_enrollment_code incoming connection & signals

### DIFF
--- a/commerce_coordinator/apps/core/signal_helpers.py
+++ b/commerce_coordinator/apps/core/signal_helpers.py
@@ -33,6 +33,7 @@ def coordinator_receiver(logger):
         return wrapper
     return decorator
 
+
 def format_signal_results(results):
     """
     Takes the return value from a signal send_robust and returns a dict with formatted results.
@@ -53,6 +54,6 @@ def format_signal_results(results):
         else:
             response_str = ""
 
-        result_dict = { receiver_name: { "response": response_str, "error": exception_occurred } }
+        result_dict = {receiver_name: {"response": response_str, "error": exception_occurred}}
         data.update(result_dict)
     return data

--- a/commerce_coordinator/apps/demo_lms/views.py
+++ b/commerce_coordinator/apps/demo_lms/views.py
@@ -2,11 +2,11 @@
 Views for the Demo LMS app which implement the API endpoints or callback handlers.
 """
 
-import traceback
-
 from django.http import JsonResponse
 
 from commerce_coordinator.apps.core.signals import test_signal
+from commerce_coordinator.apps.core.signal_helpers import format_signal_results
+
 
 from .filters import SampleDataRequested
 from .signals import purchase_complete_signal
@@ -16,22 +16,7 @@ def _format_signal_send_response(results):
     """
     Takes the return value from a signal send_robust and returns a JSON HTTP response
     """
-    # The results of a send_robust are a tuple of a reference to the method called and the exception, if one was raised
-    data = {}
-    for receiver, response in results:
-        receiver_name = str(receiver)
-
-        if response and response.__traceback__:
-            traceback_list = traceback.format_tb(response.__traceback__)
-            response_str = str(response) + " " + "\n".join(traceback_list)
-        elif response:
-            response_str = str(response)
-        else:
-            response_str = ""
-
-        result_dict = {receiver_name: response_str}
-        data.update(result_dict)
-
+    data = format_signal_results(results)
     return JsonResponse(data)
 
 

--- a/commerce_coordinator/apps/ecommerce/apps.py
+++ b/commerce_coordinator/apps/ecommerce/apps.py
@@ -7,4 +7,4 @@ from django.apps import AppConfig
 
 class EcommerceConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'ecommerce'
+    name = 'commerce_coordinator.apps.ecommerce'

--- a/commerce_coordinator/apps/ecommerce/signals.py
+++ b/commerce_coordinator/apps/ecommerce/signals.py
@@ -1,0 +1,10 @@
+"""
+Ecommerce signals and receivers.
+"""
+import logging
+
+from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal
+
+logger = logging.getLogger(__name__)
+
+enrollment_code_redemption_requested_signal = CoordinatorSignal()

--- a/commerce_coordinator/apps/ecommerce/urls.py
+++ b/commerce_coordinator/apps/ecommerce/urls.py
@@ -1,0 +1,13 @@
+"""
+ecommerce app URLS
+"""
+
+from django.urls import include, path
+
+from commerce_coordinator.apps.ecommerce.views import RedeemEnrollmentCodeView
+
+app_name = 'ecommerce'
+urlpatterns = [
+    path('redeem_enrollment_code/', RedeemEnrollmentCodeView.as_view(), name='redeem_enrollment_code'),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+]

--- a/commerce_coordinator/apps/ecommerce/views.py
+++ b/commerce_coordinator/apps/ecommerce/views.py
@@ -1,7 +1,40 @@
 """
-Views for the ecommerce app which implement the API endpoints or callback handlers.
+Views for the frontend_app_ecommerce app
 """
+import logging
 
-# from django.shortcuts import render
+from edx_rest_framework_extensions.permissions import LoginRedirectIfUnauthenticated
+from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
+from rest_framework.views import APIView
 
-# Create your views here.
+from commerce_coordinator.apps.core.signal_helpers import format_signal_results
+
+from .signals import enrollment_code_redemption_requested_signal
+
+logger = logging.getLogger(__name__)
+
+class RedeemEnrollmentCodeView(APIView):
+    """User requests to redeem enrollment code."""
+    permission_classes = [LoginRedirectIfUnauthenticated]
+    throttle_classes = [UserRateThrottle]
+
+    def get(self, request):
+        """Return paginated response of user's order history."""
+
+        code = request.query_params.get('code')
+        sku = request.query_params.get('sku')
+
+        if not code:
+            return Response({'error': 'Code not provided.'})
+        if not sku:
+            return Response({'error': 'SKU not provided.'})
+
+        results = enrollment_code_redemption_requested_signal.send_robust(
+            sender=self.__class__,
+            user_id=request.user.id,
+            sku=sku,
+            enrollment_code=code,
+        )
+
+        return Response(format_signal_results(results))

--- a/commerce_coordinator/apps/ecommerce/views.py
+++ b/commerce_coordinator/apps/ecommerce/views.py
@@ -14,6 +14,7 @@ from .signals import enrollment_code_redemption_requested_signal
 
 logger = logging.getLogger(__name__)
 
+
 class RedeemEnrollmentCodeView(APIView):
     """User requests to redeem enrollment code."""
     permission_classes = [LoginRedirectIfUnauthenticated]

--- a/commerce_coordinator/apps/frontend_app_ecommerce/apps.py
+++ b/commerce_coordinator/apps/frontend_app_ecommerce/apps.py
@@ -6,4 +6,4 @@ from django.apps import AppConfig
 
 
 class FrontendAppEcommerceConfig(AppConfig):
-    name = 'frontend_app_ecommerce'
+    name = 'commerce_coordinator.apps.frontend_app_ecommerce'

--- a/commerce_coordinator/apps/titan/apps.py
+++ b/commerce_coordinator/apps/titan/apps.py
@@ -7,4 +7,4 @@ from django.apps import AppConfig
 
 class TitanConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'titan'
+    name = 'commerce_coordinator.apps.titan'

--- a/commerce_coordinator/apps/titan/signals.py
+++ b/commerce_coordinator/apps/titan/signals.py
@@ -1,0 +1,23 @@
+"""
+Titan app signals and receivers.
+"""
+import logging
+
+from commerce_coordinator.apps.core.signal_helpers import coordinator_receiver
+from commerce_coordinator.apps.titan.tasks import (
+    enrollment_code_redemption_requested_create_order_task,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@coordinator_receiver(logger)
+def enrollment_code_redemption_requested_create_order(**kwargs):
+    """
+    Create an order using the requested enrollment code.
+    """
+    enrollment_code_redemption_requested_create_order_task.delay(
+        kwargs['user_id'],
+        kwargs['sku'],
+        kwargs['enrollment_code'],
+    )

--- a/commerce_coordinator/apps/titan/tasks.py
+++ b/commerce_coordinator/apps/titan/tasks.py
@@ -13,5 +13,5 @@ def enrollment_code_redemption_requested_create_order_task(user_id, sku, enrollm
     """
     Enrollment code redemption.
     """
-    logger.info('Titan enrollment_code_redemption_requested_create_order_task fired ' \
+    logger.info('Titan enrollment_code_redemption_requested_create_order_task fired '
                 f'with user {user_id} and sku {sku} and enrollment_code {enrollment_code}.')

--- a/commerce_coordinator/apps/titan/tasks.py
+++ b/commerce_coordinator/apps/titan/tasks.py
@@ -1,0 +1,17 @@
+"""
+Titan Celery tasks
+"""
+from celery import shared_task
+from celery.utils.log import get_task_logger
+
+# Use the special Celery logger for our tasks
+logger = get_task_logger(__name__)
+
+
+@shared_task()
+def enrollment_code_redemption_requested_create_order_task(user_id, sku, enrollment_code):
+    """
+    Enrollment code redemption.
+    """
+    logger.info('Titan enrollment_code_redemption_requested_create_order_task fired ' \
+                f'with user {user_id} and sku {sku} and enrollment_code {enrollment_code}.')

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -51,6 +51,9 @@ THIRD_PARTY_APPS = (
 PROJECT_APPS = (
     'commerce_coordinator.apps.core.apps.CoreConfig',
     'commerce_coordinator.apps.api',
+    'commerce_coordinator.apps.ecommerce.apps.EcommerceConfig',
+    'commerce_coordinator.apps.frontend_app_ecommerce.apps.FrontendAppEcommerceConfig',
+    'commerce_coordinator.apps.titan.apps.TitanConfig',
 )
 
 INSTALLED_APPS += THIRD_PARTY_APPS
@@ -278,6 +281,9 @@ CC_SIGNALS = {
     ],
     'commerce_coordinator.apps.demo_lms.signals.enroll_learner_signal': [
         'commerce_coordinator.apps.demo_lms.signals.demo_enroll_learner_in_course',
+    ],
+    'commerce_coordinator.apps.ecommerce.signals.enrollment_code_redemption_requested_signal': [
+        'commerce_coordinator.apps.titan.signals.enrollment_code_redemption_requested_create_order',
     ],
 }
 

--- a/commerce_coordinator/urls.py
+++ b/commerce_coordinator/urls.py
@@ -31,16 +31,18 @@ from rest_framework_swagger.views import get_swagger_view
 from commerce_coordinator.apps.api import urls as api_urls
 from commerce_coordinator.apps.core import views as core_views
 from commerce_coordinator.apps.demo_lms import urls as demo_lms_urls
+from commerce_coordinator.apps.ecommerce import urls as ecommerce_urls
 from commerce_coordinator.apps.frontend_app_ecommerce import urls as orders_urls
 
 admin.autodiscover()
 
 urlpatterns = oauth2_urlpatterns + [
-    path('admin/', admin.site.urls),
-    path('api/', include(api_urls)),
-    path('api-docs/', get_swagger_view(title='commerce-coordinator API')),
-    path('auto_auth/', core_views.AutoAuth.as_view(), name='auto_auth'),
     path('', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
+    path('admin/', admin.site.urls),
+    path('api-docs/', get_swagger_view(title='commerce-coordinator API')),
+    path('api/', include(api_urls)),
+    path('auto_auth/', core_views.AutoAuth.as_view(), name='auto_auth'),
+    path('ecommerce/', include(ecommerce_urls), name='ecommerce'),
     path('health/', core_views.health, name='health'),
     path('orders/', include(orders_urls)),
     # DEMO: Currently this is only test code, we may want to decouple LMS code here at some point...


### PR DESCRIPTION
## Description

We are doing an internal hackathon for some rapid prototyping in the Coordinator. The objective of this hackathon is to get proof of concept code for redeeming enrollment codes (aka 100% coupons) via an existing ecommerce system in our company called Titan.

This PR adds:
* An incoming external connection through a new Coordinator API resource at `/ecommerce/redeem_enrollment_code`
* A internal connection through a new signal called `enrollment_code_redemption_requested_signal` and its receiver `enrollment_code_redemption_requested_create_order`
* A Celery task called `enrollment_code_redemption_requested_create_order_task` that will in the future call the Titan `/redeemEnrollmentCode` endpoint in a future PR in this repo.

## Additional information

* Jira: [REV-2847](https://2u-internal.atlassian.net/browse/REV-2847)
* Previous art: https://github.com/edx/commerce-coordinator/pull/44
* Draft sequence diagram:
    ```mermaid
    sequenceDiagram
        actor user as User
        participant lms as edX LMS
        participant ecommerce as edX Ecommerce
        participant frontend as Enrollment Page Frontend
        participant coordinator as edX Coordinator
        participant titan as Titan
        user->>frontend: GET {enrollment code URL}
        frontend->>+coordinator: POST /redeem_enrollment_code
        coordinator->>-titan: POST /redeemEnrollmentCode
        titan->>+coordinator: GET /checkEnrollmentCode
        coordinator->>+ecommerce: GET /coupons/check/[id]
        ecommerce-->>-coordinator: /coupons/check/[id] response
        coordinator-->>-titan: /checkEnrollmentCode response
        titan->>+coordinator: POST /fulfill
        coordinator->>ecommerce: POST /coupons/invalidate/[id]
        coordinator->>-lms: POST /api/enrollment/v1/enrollment
    ```
* Objective of this PR is to implement `frontend->>+coordinator: POST /redeem_enrollment_code` and add the wiring for `coordinator->>-titan: POST /redeemEnrollmentCode` to happen in the Coordinator.

## Testing instructions

It is a known issue this PR has no tests. Tests will be created after the proof of concept hackathon.