### PR TITLE
feat: [REV-2847] add TitanAPIClient and TitanOAuthAPIClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ unittests.xml
 # PII annotation reports
 pii_report
 
+# Reserved keyword reports
+reports/
+
 ### Internationalization artifacts
 *.mo
 *.po

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,9 @@ Note: this setup process is temporary; we will be working on a Tutor plugin
   # Return to the commerce-coordinator repo directory and provision credentials:
   bash local-provision-commerce-coordinator.sh
 
+  # compile static assets
+  python manage.py collectstatic
+
   # run commerce-coordinator locally (run inside the venv)
   python manage.py runserver localhost:8140 --settings=commerce_coordinator.settings.local
 

--- a/commerce_coordinator/apps/core/clients.py
+++ b/commerce_coordinator/apps/core/clients.py
@@ -9,7 +9,25 @@ from edx_rest_api_client.client import OAuthAPIClient
 logger = logging.getLogger(__name__)
 
 
-class BaseEdxOAuthClient:
+class Client:
+    """
+    Base class for API clients.
+    """
+
+    @property
+    def normal_timeout(self):
+        """
+        Shortcut for a normal timeout. Must be manually applied to each request.
+
+        See https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts.
+        """
+        return (
+            settings.REQUEST_CONNECT_TIMEOUT_SECONDS,
+            settings.REQUEST_READ_TIMEOUT_SECONDS
+        )
+
+
+class BaseEdxOAuthClient(Client):
     """
     API client for calls to the other edX services.
     """
@@ -19,10 +37,7 @@ class BaseEdxOAuthClient:
             settings.SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT.strip('/'),
             self.oauth2_client_id,
             self.oauth2_client_secret,
-            timeout=(
-                settings.REQUEST_CONNECT_TIMEOUT_SECONDS,
-                settings.REQUEST_READ_TIMEOUT_SECONDS
-            )
+            timeout=self.normal_timeout
         )
 
     @property

--- a/commerce_coordinator/apps/ecommerce/clients.py
+++ b/commerce_coordinator/apps/ecommerce/clients.py
@@ -2,6 +2,7 @@
 API clients for ecommerce app.
 """
 import logging
+from urllib.parse import urljoin
 
 import requests
 from django.conf import settings
@@ -15,7 +16,7 @@ class EcommerceApiClient(BaseEdxOAuthClient):
     """
     API client for calls to the edX Ecommerce service.
     """
-    api_base_url = str(settings.ECOMMERCE_URL).strip('/') + '/api/v2'
+    api_base_url = urljoin(settings.ECOMMERCE_URL, '/api/v2')
 
     def get_orders(self, query_params):
         """
@@ -30,7 +31,7 @@ class EcommerceApiClient(BaseEdxOAuthClient):
 
         """
         try:
-            resource_url = self.api_base_url + '/orders'
+            resource_url = urljoin(self.api_base_url, '/orders')
             response = self.client.get(resource_url, params=query_params)
             response.raise_for_status()
             return response.json()

--- a/commerce_coordinator/apps/ecommerce/clients.py
+++ b/commerce_coordinator/apps/ecommerce/clients.py
@@ -30,7 +30,7 @@ class EcommerceApiClient(BaseEdxOAuthClient):
 
         """
         try:
-            resource_url= self.api_base_url + '/orders'
+            resource_url = self.api_base_url + '/orders'
             response = self.client.get(resource_url, params=query_params)
             response.raise_for_status()
             return response.json()

--- a/commerce_coordinator/apps/ecommerce/clients.py
+++ b/commerce_coordinator/apps/ecommerce/clients.py
@@ -15,7 +15,7 @@ class EcommerceApiClient(BaseEdxOAuthClient):
     """
     API client for calls to the edX Ecommerce service.
     """
-    api_base_url = str(settings.ECOMMERCE_URL) + '/api/v2/'
+    api_base_url = str(settings.ECOMMERCE_URL).strip('/') + '/api/v2'
 
     def get_orders(self, query_params):
         """
@@ -30,8 +30,8 @@ class EcommerceApiClient(BaseEdxOAuthClient):
 
         """
         try:
-            endpoint = self.api_base_url + 'orders/'
-            response = self.client.get(endpoint, params=query_params)
+            resource_url= self.api_base_url + '/orders'
+            response = self.client.get(resource_url, params=query_params)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.HTTPError as exc:

--- a/commerce_coordinator/apps/ecommerce/clients.py
+++ b/commerce_coordinator/apps/ecommerce/clients.py
@@ -12,7 +12,7 @@ from commerce_coordinator.apps.core.clients import BaseEdxOAuthClient
 logger = logging.getLogger(__name__)
 
 
-class EcommerceApiClient(BaseEdxOAuthClient):
+class EcommerceAPIClient(BaseEdxOAuthClient):
     """
     API client for calls to the edX Ecommerce service.
     """

--- a/commerce_coordinator/apps/ecommerce/pipeline.py
+++ b/commerce_coordinator/apps/ecommerce/pipeline.py
@@ -4,7 +4,7 @@ Ecommerce filter pipelines
 
 from openedx_filters import PipelineStep
 
-from commerce_coordinator.apps.ecommerce.clients import EcommerceApiClient
+from commerce_coordinator.apps.ecommerce.clients import EcommerceAPIClient
 
 
 class GetEcommerceOrders(PipelineStep):
@@ -20,7 +20,7 @@ class GetEcommerceOrders(PipelineStep):
             order_data: any preliminary orders (from earlier pipeline step) we want to append to
         """
 
-        ecommerce_api_client = EcommerceApiClient()
+        ecommerce_api_client = EcommerceAPIClient()
         ecommerce_response = ecommerce_api_client.get_orders(params)
 
         order_data.append(ecommerce_response)

--- a/commerce_coordinator/apps/ecommerce/signals.py
+++ b/commerce_coordinator/apps/ecommerce/signals.py
@@ -1,10 +1,6 @@
 """
 Ecommerce signals and receivers.
 """
-import logging
-
 from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal
-
-logger = logging.getLogger(__name__)
 
 enrollment_code_redemption_requested_signal = CoordinatorSignal()

--- a/commerce_coordinator/apps/ecommerce/tests/__init__.py
+++ b/commerce_coordinator/apps/ecommerce/tests/__init__.py
@@ -1,6 +1,6 @@
 """Constants for ecommerce app tests."""
 
-# Sample response from EcommerceApiClient.get_orders
+# Sample response from EcommerceAPIClient.get_orders
 ECOMMERCE_REQUEST_EXPECTED_RESPONSE = {
     'count': 1,
     'results': [

--- a/commerce_coordinator/apps/ecommerce/tests/test_clients.py
+++ b/commerce_coordinator/apps/ecommerce/tests/test_clients.py
@@ -6,7 +6,7 @@ import logging
 from django.test import TestCase
 from mock import patch
 
-from commerce_coordinator.apps.ecommerce.clients import EcommerceApiClient
+from commerce_coordinator.apps.ecommerce.clients import EcommerceAPIClient
 from commerce_coordinator.apps.frontend_app_ecommerce.tests import (
     ECOMMERCE_REQUEST_EXPECTED_RESPONSE,
     ORDER_HISTORY_GET_PARAMETERS
@@ -20,11 +20,11 @@ class EcommerceClientTests(TestCase):
     Verify endpoint availability for order retrieval endpoint(s)
     """
 
-    @patch('commerce_coordinator.apps.ecommerce.clients.EcommerceApiClient.get_orders')
+    @patch('commerce_coordinator.apps.ecommerce.clients.EcommerceAPIClient.get_orders')
     def test_ecommerce_api_client(self, mock_response):
-        """We can call the EcommerceApiClient successfully."""
+        """We can call the EcommerceAPIClient successfully."""
         mock_response.return_value = ECOMMERCE_REQUEST_EXPECTED_RESPONSE
 
-        ecommerce_api_client = EcommerceApiClient()
+        ecommerce_api_client = EcommerceAPIClient()
         ecommerce_response = ecommerce_api_client.get_orders(ORDER_HISTORY_GET_PARAMETERS)
         self.assertEqual(ECOMMERCE_REQUEST_EXPECTED_RESPONSE, ecommerce_response)

--- a/commerce_coordinator/apps/ecommerce/views.py
+++ b/commerce_coordinator/apps/ecommerce/views.py
@@ -1,8 +1,6 @@
 """
 Views for the ecommerce app
 """
-import logging
-
 from edx_rest_framework_extensions.permissions import LoginRedirectIfUnauthenticated
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
@@ -11,8 +9,6 @@ from rest_framework.views import APIView
 from commerce_coordinator.apps.core.signal_helpers import format_signal_results
 
 from .signals import enrollment_code_redemption_requested_signal
-
-logger = logging.getLogger(__name__)
 
 
 class RedeemEnrollmentCodeView(APIView):

--- a/commerce_coordinator/apps/ecommerce/views.py
+++ b/commerce_coordinator/apps/ecommerce/views.py
@@ -29,7 +29,7 @@ class RedeemEnrollmentCodeView(APIView):
             Dictionary with results from signal dispatch to redeem an enrollment code.
 
         Raises:
-            PermissionDenied: Djano was unable to determine the user's id or email.
+            PermissionDenied: Djano was unable to determine the user's id, username, or email.
         """
 
         sku = request.query_params.get('sku')
@@ -37,6 +37,8 @@ class RedeemEnrollmentCodeView(APIView):
 
         if not request.user.id:
             raise PermissionDenied(detail="Could not detect user id.")
+        if not request.user.username:
+            raise PermissionDenied(detail="Could not detect username.")
         if not request.user.email:
             raise PermissionDenied(detail="Could not detect user email.")
 
@@ -48,6 +50,7 @@ class RedeemEnrollmentCodeView(APIView):
         results = enrollment_code_redemption_requested_signal.send_robust(
             sender=self.__class__,
             user_id=request.user.id,
+            username=request.user.username,
             email=request.user.email,
             sku=sku,
             coupon_code=code,

--- a/commerce_coordinator/apps/ecommerce/views.py
+++ b/commerce_coordinator/apps/ecommerce/views.py
@@ -27,6 +27,9 @@ class RedeemEnrollmentCodeView(APIView):
 
         Returns:
             Dictionary with results from signal dispatch to redeem an enrollment code.
+
+        Raises:
+            PermissionDenied: Djano was unable to determine the user's id or email.
         """
 
         sku = request.query_params.get('sku')

--- a/commerce_coordinator/apps/ecommerce/views.py
+++ b/commerce_coordinator/apps/ecommerce/views.py
@@ -2,6 +2,7 @@
 Views for the ecommerce app
 """
 from edx_rest_framework_extensions.permissions import LoginRedirectIfUnauthenticated
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
@@ -17,21 +18,33 @@ class RedeemEnrollmentCodeView(APIView):
     throttle_classes = [UserRateThrottle]
 
     def get(self, request):
-        """Return paginated response of user's order history."""
+        """
+        Redeem an enrollment code for an authenticated user.
 
-        code = request.query_params.get('code')
+        Args:
+            sku: ecommerce partner_sku to be redeemed
+            code: enrollment code (aka, 100 percent off coupon code) to redeem.
+
+        Returns:
+            Dictionary with results from signal dispatch to redeem an enrollment code.
+        """
+
         sku = request.query_params.get('sku')
+        code = request.query_params.get('code')
 
-        if not code:
-            return Response({'error': 'Code not provided.'})
+        if not request.user.id or not request.user.email:
+            raise PermissionDenied(detail="Could not detect user id or email.")
         if not sku:
             return Response({'error': 'SKU not provided.'})
+        if not code:
+            return Response({'error': 'Code not provided.'})
 
         results = enrollment_code_redemption_requested_signal.send_robust(
             sender=self.__class__,
             user_id=request.user.id,
+            email=request.user.email,
             sku=sku,
-            enrollment_code=code,
+            coupon_code=code,
         )
 
         return Response(format_signal_results(results))

--- a/commerce_coordinator/apps/ecommerce/views.py
+++ b/commerce_coordinator/apps/ecommerce/views.py
@@ -35,8 +35,11 @@ class RedeemEnrollmentCodeView(APIView):
         sku = request.query_params.get('sku')
         code = request.query_params.get('code')
 
-        if not request.user.id or not request.user.email:
-            raise PermissionDenied(detail="Could not detect user id or email.")
+        if not request.user.id:
+            raise PermissionDenied(detail="Could not detect user id.")
+        if not request.user.email:
+            raise PermissionDenied(detail="Could not detect user email.")
+
         if not sku:
             return Response({'error': 'SKU not provided.'})
         if not code:

--- a/commerce_coordinator/apps/frontend_app_ecommerce/tests/__init__.py
+++ b/commerce_coordinator/apps/frontend_app_ecommerce/tests/__init__.py
@@ -3,7 +3,7 @@
 # Test parameters used by order history endpoint
 ORDER_HISTORY_GET_PARAMETERS = {'username': 'TestUser', "page": 1, "page_size": 20}
 
-# Sample response from EcommerceApiClient.get_orders
+# Sample response from EcommerceAPIClient.get_orders
 ECOMMERCE_REQUEST_EXPECTED_RESPONSE = {
     'count': 1,
     'results': [

--- a/commerce_coordinator/apps/frontend_app_ecommerce/tests/test_filters.py
+++ b/commerce_coordinator/apps/frontend_app_ecommerce/tests/test_filters.py
@@ -13,7 +13,7 @@ from commerce_coordinator.apps.frontend_app_ecommerce.tests import (
 from commerce_coordinator.apps.frontend_app_ecommerce.tests.test_views import EcommerceClientMock
 
 
-@patch('commerce_coordinator.apps.ecommerce.clients.EcommerceApiClient.get_orders',
+@patch('commerce_coordinator.apps.ecommerce.clients.EcommerceAPIClient.get_orders',
        new_callable=EcommerceClientMock)
 class TestFrontendAppEcommerceFilters(TestCase):
     """

--- a/commerce_coordinator/apps/frontend_app_ecommerce/tests/test_views.py
+++ b/commerce_coordinator/apps/frontend_app_ecommerce/tests/test_views.py
@@ -19,11 +19,11 @@ logger = logging.getLogger(__name__)
 
 
 class EcommerceClientMock(MagicMock):
-    """A mock EcommerceApiClient that always returns ECOMMERCE_REQUEST_EXPECTED_RESPONSE."""
+    """A mock EcommerceAPIClient that always returns ECOMMERCE_REQUEST_EXPECTED_RESPONSE."""
     return_value = ECOMMERCE_REQUEST_EXPECTED_RESPONSE
 
 
-@patch('commerce_coordinator.apps.ecommerce.clients.EcommerceApiClient.get_orders',
+@patch('commerce_coordinator.apps.ecommerce.clients.EcommerceAPIClient.get_orders',
        new_callable=EcommerceClientMock)
 class OrdersViewTests(TestCase):
     """

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -8,11 +8,13 @@ from celery.utils.log import get_task_logger
 from django.conf import settings
 from edx_rest_api_client.client import OAuthAPIClient
 
+from commerce_coordinator.apps.core.clients import Client
+
 # Use special Celery logger for tasks client calls.
 logger = get_task_logger(__name__)
 
 
-class TitanAPIClient():
+class TitanAPIClient(Client):
     """
     API client for calls to Titan using API key.
     """
@@ -31,18 +33,6 @@ class TitanAPIClient():
     def api_key_header(self):
         """Header to add to all API requests to authenticate to endpoint."""
         return {'X-API-Key': settings.TITAN_API_KEY}
-
-    @property
-    def normal_timeout(self):
-        """
-        Shortcut for a normal timeout. Must be manually applied to each request.
-
-        See https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts.
-        """
-        return (
-            settings.REQUEST_CONNECT_TIMEOUT_SECONDS,
-            settings.REQUEST_READ_TIMEOUT_SECONDS
-        )
 
     def post(self, resource_path, data):
         """
@@ -85,10 +75,7 @@ class TitanOAuthAPIClient(TitanAPIClient):
             settings.TITAN_OAUTH2_PROVIDER_URL,
             self.oauth2_client_id,
             self.oauth2_client_secret,
-            timeout=(
-                settings.REQUEST_CONNECT_TIMEOUT_SECONDS,
-                settings.REQUEST_READ_TIMEOUT_SECONDS
-            )
+            timeout=self.normal_timeout
         )
         # Always send API key.
         self.client.headers.update(self.api_key_header)

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -1,0 +1,103 @@
+"""
+API clients for Titan.
+"""
+
+import requests
+from celery.utils.log import get_task_logger
+from django.conf import settings
+from edx_rest_api_client.client import OAuthAPIClient
+
+# Use special Celery logger for tasks client calls.
+logger = get_task_logger(__name__)
+
+
+class TitanAPIClient():
+    """
+    API client for calls to Titan using API key.
+    """
+
+    def __init__(self):
+        self.client = requests.Session()
+        # Always send API key.
+        self.client.headers.update(self.api_key_header)
+
+    @property
+    def api_base_url(self):
+        """URL of API service."""
+        return str(settings.TITAN_URL).strip('/') + '/v1'
+
+    @property
+    def api_key_header(self):
+        """Header to add to all API requests to authenticate to endpoint."""
+        return {'X-API-Key': settings.TITAN_API_KEY}
+
+    @property
+    def normal_timeout(self):
+        """
+        Shortcut for a normal timeout. Must be manually applied to each request.
+
+        See https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts.
+        """
+        return (
+            settings.REQUEST_CONNECT_TIMEOUT_SECONDS,
+            settings.REQUEST_READ_TIMEOUT_SECONDS
+        )
+
+    def post(self, resource_path, data):
+        """
+        Send a POST request to a Titan API resource.
+
+        Arguments:
+            resource_path: the path of the API resource to POST to
+            data: the dictionary to send to the API resource
+        Returns:
+            dict: Dictionary represention of JSON returned from API
+
+        """
+        try:
+            resource_url = self.api_base_url.strip('/') + resource_path
+            response = self.client.post(
+                resource_url,
+                json=data,
+                timeout=self.normal_timeout,
+            )
+            logger.debug("response: %s", response)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as exc:
+            logger.error(exc)
+            logger.debug("Request method: %s", exc.request.method)
+            logger.debug("Request URL: %s", exc.request.url)
+            logger.debug("Request headers: %s", exc.request.headers)
+            logger.debug("Request body: %s", exc.request.body)
+            raise
+
+
+class TitanOAuthAPIClient(TitanAPIClient):
+    """
+    API client for calls to Titan using OAuth bearer tokens.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.client = OAuthAPIClient(
+            settings.TITAN_OAUTH2_PROVIDER_URL,
+            self.oauth2_client_id,
+            self.oauth2_client_secret,
+            timeout=(
+                settings.REQUEST_CONNECT_TIMEOUT_SECONDS,
+                settings.REQUEST_READ_TIMEOUT_SECONDS
+            )
+        )
+        # Always send API key.
+        self.client.headers.update(self.api_key_header)
+
+    @property
+    def oauth2_client_id(self):
+        """OAuth2 Titan client id."""
+        return settings.TITAN_OAUTH2_KEY
+
+    @property
+    def oauth2_client_secret(self):
+        """OAuth2 Titan client secret."""
+        return settings.TITAN_OAUTH2_SECRET

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -31,7 +31,7 @@ class TitanAPIClient(Client):
 
     @property
     def api_key_header(self):
-        """Header to add to all API requests to authenticate to endpoint."""
+        """Header to add as API key for requests."""
         return {'X-API-Key': settings.TITAN_API_KEY}
 
     def post(self, resource_path, data):

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -1,6 +1,7 @@
 """
 API clients for Titan.
 """
+from urllib.parse import urljoin
 
 import requests
 from celery.utils.log import get_task_logger
@@ -24,7 +25,7 @@ class TitanAPIClient():
     @property
     def api_base_url(self):
         """URL of API service."""
-        return str(settings.TITAN_URL).strip('/') + '/v1'
+        return urljoin(settings.TITAN_URL, '/v1')
 
     @property
     def api_key_header(self):
@@ -55,7 +56,7 @@ class TitanAPIClient():
 
         """
         try:
-            resource_url = self.api_base_url.strip('/') + resource_path
+            resource_url = urljoin(self.api_base_url, resource_path)
             response = self.client.post(
                 resource_url,
                 json=data,

--- a/commerce_coordinator/apps/titan/signals.py
+++ b/commerce_coordinator/apps/titan/signals.py
@@ -20,12 +20,14 @@ def enrollment_code_redemption_requested_create_order(**kwargs):
     """
     enrollment_code_redemption_requested_create_order_task.delay(
         kwargs['user_id'],
+        kwargs['username'],
         kwargs['email'],
         kwargs['sku'],
         kwargs['coupon_code'],
     )
     enrollment_code_redemption_requested_create_order_oauth_task.delay(
         kwargs['user_id'],
+        kwargs['username'],
         kwargs['email'],
         kwargs['sku'],
         kwargs['coupon_code'],

--- a/commerce_coordinator/apps/titan/signals.py
+++ b/commerce_coordinator/apps/titan/signals.py
@@ -1,10 +1,14 @@
 """
 Titan app signals and receivers.
 """
+
 import logging
 
 from commerce_coordinator.apps.core.signal_helpers import coordinator_receiver
-from commerce_coordinator.apps.titan.tasks import enrollment_code_redemption_requested_create_order_task
+from commerce_coordinator.apps.titan.tasks import (
+    enrollment_code_redemption_requested_create_order_oauth_task,
+    enrollment_code_redemption_requested_create_order_task
+)
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +20,13 @@ def enrollment_code_redemption_requested_create_order(**kwargs):
     """
     enrollment_code_redemption_requested_create_order_task.delay(
         kwargs['user_id'],
+        kwargs['email'],
         kwargs['sku'],
-        kwargs['enrollment_code'],
+        kwargs['coupon_code'],
+    )
+    enrollment_code_redemption_requested_create_order_oauth_task.delay(
+        kwargs['user_id'],
+        kwargs['email'],
+        kwargs['sku'],
+        kwargs['coupon_code'],
     )

--- a/commerce_coordinator/apps/titan/tasks.py
+++ b/commerce_coordinator/apps/titan/tasks.py
@@ -12,18 +12,20 @@ logger = get_task_logger(__name__)
 
 
 @shared_task()
-def enrollment_code_redemption_requested_create_order_task(user_id, email, sku, coupon_code):
+def enrollment_code_redemption_requested_create_order_task(user_id, username, email, sku, coupon_code):
     """
     Ask to create an order to redeeem an enrollment code.
 
     Args:
         user_id: edX LMS user id redeeming enrollment code
+        username: edX LMS username of user_id
         email: edX LMS user email of user_id
         sku: ecommerce partner_sku of product to redeem
         coupon_code: enrollment code
     """
     logger.info('Titan enrollment_code_redemption_requested_create_order_task fired '
-                f'with user {user_id}, email {email}, sku {sku} and coupon code {coupon_code}.')
+                f'with user {user_id}, username {username}, email {email},'
+                f'sku {sku} and coupon code {coupon_code}.')
 
     titan_api_client = TitanAPIClient()
     titan_api_client.post(
@@ -33,24 +35,27 @@ def enrollment_code_redemption_requested_create_order_task(user_id, email, sku, 
             'productSku': sku,
             'couponCode': coupon_code,
             'edxLmsUserId': user_id,
+            'edxLmsUserName': username,
             'email': email,
         }
     )
 
 
 @shared_task()
-def enrollment_code_redemption_requested_create_order_oauth_task(user_id, email, sku, coupon_code):
+def enrollment_code_redemption_requested_create_order_oauth_task(user_id, username, email, sku, coupon_code):
     """
     Ask to create an order to redeeem an enrollment code.
 
     Args:
         user_id: edX LMS user id redeeming enrollment code
+        username: edX LMS username of user_id
         email: edX LMS user email of user_id
         sku: ecommerce partner_sku of product to redeem
         coupon_code: enrollment code
     """
     logger.info('Titan enrollment_code_redemption_requested_create_order_oauth_task fired '
-                f'with user {user_id}, email {email}, sku {sku} and coupon code {coupon_code}.')
+                f'with user {user_id}, username {username}, email {email}, '
+                f'sku {sku} and coupon code {coupon_code}.')
 
     titan_api_client = TitanOAuthAPIClient()
     titan_api_client.post(
@@ -60,6 +65,7 @@ def enrollment_code_redemption_requested_create_order_oauth_task(user_id, email,
             'productSku': sku,
             'couponCode': coupon_code,
             'edxLmsUserId': user_id,
+            'edxLmsUserName': username,
             'email': email,
         }
     )

--- a/commerce_coordinator/apps/titan/tasks.py
+++ b/commerce_coordinator/apps/titan/tasks.py
@@ -1,17 +1,64 @@
 """
 Titan Celery tasks
 """
+
 from celery import shared_task
 from celery.utils.log import get_task_logger
+
+from .clients import TitanAPIClient, TitanOAuthAPIClient
 
 # Use the special Celery logger for our tasks
 logger = get_task_logger(__name__)
 
 
 @shared_task()
-def enrollment_code_redemption_requested_create_order_task(user_id, sku, enrollment_code):
+def enrollment_code_redemption_requested_create_order_task(user_id, email, sku, coupon_code):
     """
-    Enrollment code redemption.
+    Ask to create an order to redeeem an enrollment code.
+
+    Args:
+        user_id: edX LMS user id redeeming enrollment code
+        email: edX LMS user email of user_id
+        sku: ecommerce partner_sku of product to redeem
+        coupon_code: enrollment code
     """
     logger.info('Titan enrollment_code_redemption_requested_create_order_task fired '
-                f'with user {user_id} and sku {sku} and enrollment_code {enrollment_code}.')
+                f'with user {user_id}, email {email}, sku {sku} and coupon code {coupon_code}.')
+
+    titan_api_client = TitanAPIClient()
+    titan_api_client.post(
+        '/enrollment-code-redemptions',
+        {
+            'source': 'edx',
+            'productSku': sku,
+            'couponCode': coupon_code,
+            'edxLmsUserId': user_id,
+            'email': email,
+        }
+    )
+
+@shared_task()
+def enrollment_code_redemption_requested_create_order_oauth_task(user_id, email, sku, coupon_code):
+    """
+    Ask to create an order to redeeem an enrollment code.
+
+    Args:
+        user_id: edX LMS user id redeeming enrollment code
+        email: edX LMS user email of user_id
+        sku: ecommerce partner_sku of product to redeem
+        coupon_code: enrollment code
+    """
+    logger.info('Titan enrollment_code_redemption_requested_create_order_oauth_task fired '
+                f'with user {user_id}, email {email}, sku {sku} and coupon code {coupon_code}.')
+
+    titan_api_client = TitanOAuthAPIClient()
+    titan_api_client.post(
+        '/enrollment-code-redemptions',
+        {
+            'source': 'edx',
+            'productSku': sku,
+            'couponCode': coupon_code,
+            'edxLmsUserId': user_id,
+            'email': email,
+        }
+    )

--- a/commerce_coordinator/apps/titan/tasks.py
+++ b/commerce_coordinator/apps/titan/tasks.py
@@ -37,6 +37,7 @@ def enrollment_code_redemption_requested_create_order_task(user_id, email, sku, 
         }
     )
 
+
 @shared_task()
 def enrollment_code_redemption_requested_create_order_oauth_task(user_id, email, sku, coupon_code):
     """

--- a/commerce_coordinator/celery_app.py
+++ b/commerce_coordinator/celery_app.py
@@ -21,9 +21,11 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
 
 
-# Dive deeper into calls to log debug messages in tasks if Django logging level is also set to debug.
 @celery.signals.after_setup_task_logger.connect
 def on_after_setup_task_logger(**kwargs):
+    """
+    Dive deeper into calls to log debug messages in tasks if Django logging level is also set to debug.
+    """
     if django.conf.settings.DEBUG:
         logger = kwargs["logger"]
         logger.setLevel(logging.DEBUG)

--- a/commerce_coordinator/celery_app.py
+++ b/commerce_coordinator/celery_app.py
@@ -20,6 +20,7 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 # app in INSTALLED_APPS should automatically be found.
 app.autodiscover_tasks()
 
+
 # Dive deeper into calls to log debug messages in tasks if Django logging level is also set to debug.
 @celery.signals.after_setup_task_logger.connect
 def on_after_setup_task_logger(**kwargs):

--- a/commerce_coordinator/celery_app.py
+++ b/commerce_coordinator/celery_app.py
@@ -4,16 +4,25 @@ Celery app needed to configure using Django settings, and make Celery tasks avai
 https://docs.celeryproject.org/en/stable/django/first-steps-with-django.html
 """
 
+import logging
 import os
 
-from celery import Celery
+import celery
+import django.conf
 
 # Set the default configuration module, if one is not aleady defined.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'commerce_coordinator.settings.local')
 
-app = Celery('commerce-coordinator')
+app = celery.Celery('commerce-coordinator')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # Load task modules from all registered Django apps. Any Celery tasks located in a tasks.py file under a Django
 # app in INSTALLED_APPS should automatically be found.
 app.autodiscover_tasks()
+
+# Dive deeper into calls to log debug messages in tasks if Django logging level is also set to debug.
+@celery.signals.after_setup_task_logger.connect
+def on_after_setup_task_logger(**kwargs):
+    if django.conf.settings.DEBUG:
+        logger = kwargs["logger"]
+        logger.setLevel(logging.DEBUG)

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -240,6 +240,9 @@ EXTRA_SCOPE = ['permissions']
 
 # TODO Set this to another (non-staff, ideally) path.
 LOGIN_REDIRECT_URL = '/admin/'
+
+# Set token credentials for non-edX services.
+TITAN_API_KEY = 'replace-me'
 # END AUTHENTICATION CONFIGURATION
 
 # DRF CONFIGURATION
@@ -294,7 +297,8 @@ REQUEST_CONNECT_TIMEOUT_SECONDS = 3.05
 REQUEST_READ_TIMEOUT_SECONDS = 5
 
 # API URLs
-ECOMMERCE_URL = None
+ECOMMERCE_URL = 'replace-me'
+TITAN_URL = 'replace-me'
 
 # Filters PoC
 OPEN_EDX_FILTERS_CONFIG = {

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -243,6 +243,11 @@ LOGIN_REDIRECT_URL = '/admin/'
 
 # Set token credentials for non-edX services.
 TITAN_API_KEY = 'replace-me'
+
+# Set OAuth2 credentials for non-edX services.
+TITAN_OAUTH2_PROVIDER_URL = 'replace-me'
+TITAN_OAUTH2_KEY = 'replace-me'
+TITAN_OAUTH2_SECRET = 'replace-me'
 # END AUTHENTICATION CONFIGURATION
 
 # DRF CONFIGURATION

--- a/commerce_coordinator/settings/devstack.py
+++ b/commerce_coordinator/settings/devstack.py
@@ -23,4 +23,4 @@ CELERY_BROKER_URL = "redis://:password@edx.devstack.redis:6379/0"
 
 # Application URLs in devstack.
 ECOMMERCE_URL = "http://edx.devstack.ecommerce:18130"
-TITAN_URL = None
+TITAN_URL = "http://localhost/replace-me"

--- a/commerce_coordinator/settings/devstack.py
+++ b/commerce_coordinator/settings/devstack.py
@@ -1,5 +1,6 @@
 from commerce_coordinator.settings.local import *
 
+# Use edx.devstack.mysql for database.
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
@@ -13,43 +14,13 @@ DATABASES = {
     }
 }
 
-# Generic OAuth2 variables irrespective of SSO/backend service key types.
+# Wire internal OAuth2 URLs to use internal devstack networking.
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
-
-# OAuth2 variables specific to social-auth/SSO login use case.
-SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'commerce-coordinator-sso-key')
-SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'commerce-coordinator-sso-secret')
-SOCIAL_AUTH_EDX_OAUTH2_ISSUER = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_ISSUER', 'http://localhost:18000')
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT', 'http://edx.devstack.lms:18000')
-SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL', 'http://localhost:18000/logout')
-SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = os.environ.get(
-    'SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT', 'http://localhost:18000',
-)
 
-# OAuth2 variables specific to backend service API calls.
-BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get(
-    'BACKEND_SERVICE_EDX_OAUTH2_KEY',
-    'commerce-coordinator-backend-service-key'
-)
-BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get(
-    'BACKEND_SERVICE_EDX_OAUTH2_SECRET',
-    'commerce-coordinator-backend-service-secret'
-)
+# Use edx.devstack.redis for queue.
+CELERY_BROKER_URL = "redis://:password@edx.devstack.redis:6379/0"
 
-JWT_AUTH.update({
-    'JWT_SECRET_KEY': 'lms-secret',
-    'JWT_ISSUER': 'http://localhost:18000/oauth2',
-    'JWT_AUDIENCE': None,
-    'JWT_VERIFY_AUDIENCE': False,
-    'JWT_PUBLIC_SIGNING_JWK_SET': (
-        '{"keys": [{"kid": "devstack_key", "e": "AQAB", "kty": "RSA", "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu'
-        '48BUI5VcVtUWIPqzRK_LDSlZYh9D0YFL0ZTxIrlb6Tn3Xz7pYvpIAeYuQv3_H5p8tbz7Fb8r63c1828wXPITVTv8f7oxx5W3lFFgpFAyYMmROC'
-        '4Ee9qG5T38LFe8_oAuFCEntimWxN9F3P-FJQy43TL7wG54WodgiM0EgzkeLr5K6cDnyckWjTuZbWI-4ffcTgTZsL_Kq1owa_J2ngEfxMCObnzG'
-        'y5ZLcTUomo4rZLjghVpq6KZxfS6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw"}]}'
-    ),
-    'JWT_ISSUERS': [{
-        'AUDIENCE': 'lms-key',
-        'ISSUER': 'http://localhost:18000/oauth2',
-        'SECRET_KEY': 'lms-secret',
-    }],
-})
+# Application URLs in devstack.
+ECOMMERCE_URL = "http://edx.devstack.ecommerce:18130"
+TITAN_URL = None

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -109,7 +109,9 @@ CELERY_BROKER_URL = "redis://:password@localhost:6379/0"
 
 ECOMMERCE_URL = "http://localhost:18130"
 
-TITAN_URL = None
+TITAN_URL = "http://example.com"
+
+TITAN_OAUTH2_PROVIDER_URL = "http://example.com"
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -109,6 +109,8 @@ CELERY_BROKER_URL = "redis://:password@localhost:6379/0"
 
 ECOMMERCE_URL = "http://localhost:18130"
 
+TITAN_URL = None
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/docs/commerce_coordinator.apps.core.rst
+++ b/docs/commerce_coordinator.apps.core.rst
@@ -30,7 +30,7 @@ commerce\_coordinator.apps.core.apps module
    :show-inheritance:
 
 commerce\_coordinator.apps.core.clients module
-------------------------------------------------
+----------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.core.clients
    :members:

--- a/docs/commerce_coordinator.apps.ecommerce.rst
+++ b/docs/commerce_coordinator.apps.ecommerce.rst
@@ -45,6 +45,29 @@ commerce\_coordinator.apps.ecommerce.models module
    :undoc-members:
    :show-inheritance:
 
+commerce\_coordinator.apps.ecommerce.pipeline module
+----------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.ecommerce.pipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.ecommerce.signals module
+---------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.ecommerce.signals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.ecommerce.urls module
+------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.ecommerce.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 commerce\_coordinator.apps.ecommerce.views module
 -------------------------------------------------

--- a/docs/commerce_coordinator.apps.frontend_app_ecommerce.migrations.rst
+++ b/docs/commerce_coordinator.apps.frontend_app_ecommerce.migrations.rst
@@ -1,5 +1,5 @@
-commerce\_coordinator.apps.frontend_app_ecommerce.migrations package
-====================================================================
+commerce\_coordinator.apps.frontend\_app\_ecommerce.migrations package
+======================================================================
 
 Module contents
 ---------------

--- a/docs/commerce_coordinator.apps.frontend_app_ecommerce.rst
+++ b/docs/commerce_coordinator.apps.frontend_app_ecommerce.rst
@@ -1,5 +1,5 @@
-commerce\_coordinator.apps.frontend_app_ecommerce package
-=========================================================
+commerce\_coordinator.apps.frontend\_app\_ecommerce package
+===========================================================
 
 Subpackages
 -----------
@@ -13,40 +13,48 @@ Subpackages
 Submodules
 ----------
 
-commerce\_coordinator.apps.frontend_app_ecommerce.admin module
---------------------------------------------------------------
+commerce\_coordinator.apps.frontend\_app\_ecommerce.admin module
+----------------------------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.frontend_app_ecommerce.admin
    :members:
    :undoc-members:
    :show-inheritance:
 
-commerce\_coordinator.apps.frontend_app_ecommerce.apps module
--------------------------------------------------------------
+commerce\_coordinator.apps.frontend\_app\_ecommerce.apps module
+---------------------------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.frontend_app_ecommerce.apps
    :members:
    :undoc-members:
    :show-inheritance:
 
-commerce\_coordinator.apps.frontend_app_ecommerce.models module
----------------------------------------------------------------
+commerce\_coordinator.apps.frontend\_app\_ecommerce.filters module
+------------------------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.frontend_app_ecommerce.filters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.frontend\_app\_ecommerce.models module
+-----------------------------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.frontend_app_ecommerce.models
    :members:
    :undoc-members:
    :show-inheritance:
 
-commerce\_coordinator.apps.frontend_app_ecommerce.urls module
--------------------------------------------------------------
+commerce\_coordinator.apps.frontend\_app\_ecommerce.urls module
+---------------------------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.frontend_app_ecommerce.urls
    :members:
    :undoc-members:
    :show-inheritance:
 
-commerce\_coordinator.apps.frontend_app_ecommerce.views module
---------------------------------------------------------------
+commerce\_coordinator.apps.frontend\_app\_ecommerce.views module
+----------------------------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.frontend_app_ecommerce.views
    :members:

--- a/docs/commerce_coordinator.apps.frontend_app_ecommerce.tests.rst
+++ b/docs/commerce_coordinator.apps.frontend_app_ecommerce.tests.rst
@@ -1,12 +1,19 @@
-commerce\_coordinator.apps.frontend_app_ecommerce.tests package
-===============================================================
+commerce\_coordinator.apps.frontend\_app\_ecommerce.tests package
+=================================================================
 
 Submodules
 ----------
 
+commerce\_coordinator.apps.frontend\_app\_ecommerce.tests.test\_filters module
+------------------------------------------------------------------------------
 
-commerce\_coordinator.apps.frontend_app_ecommerce.tests.test\_views module
---------------------------------------------------------------------------
+.. automodule:: commerce_coordinator.apps.frontend_app_ecommerce.tests.test_filters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.frontend\_app\_ecommerce.tests.test\_views module
+----------------------------------------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.frontend_app_ecommerce.tests.test_views
    :members:

--- a/docs/commerce_coordinator.apps.rst
+++ b/docs/commerce_coordinator.apps.rst
@@ -15,7 +15,6 @@ Subpackages
    commerce_coordinator.apps.lms
    commerce_coordinator.apps.titan
 
-
 Module contents
 ---------------
 

--- a/docs/commerce_coordinator.apps.titan.rst
+++ b/docs/commerce_coordinator.apps.titan.rst
@@ -1,0 +1,86 @@
+commerce\_coordinator.apps.titan package
+========================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   commerce_coordinator.apps.titan.migrations
+   commerce_coordinator.apps.titan.tests
+
+Submodules
+----------
+
+commerce\_coordinator.apps.titan.admin module
+---------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.titan.admin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.titan.apps module
+--------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.titan.apps
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.titan.clients module
+-----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.titan.clients
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.titan.models module
+----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.titan.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.titan.signals module
+-----------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.titan.signals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.titan.tasks module
+---------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.titan.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.titan.urls module
+--------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.titan.urls
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+commerce\_coordinator.apps.titan.views module
+---------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.titan.views
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: commerce_coordinator.apps.titan
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/commerce_coordinator.apps.titan.tests.rst
+++ b/docs/commerce_coordinator.apps.titan.tests.rst
@@ -4,9 +4,8 @@ commerce\_coordinator.apps.titan.tests package
 Submodules
 ----------
 
-
 commerce\_coordinator.apps.titan.tests.test\_views module
-----------------------------------------------------------
+---------------------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.titan.tests.test_views
    :members:


### PR DESCRIPTION
## Description

We are doing an internal hackathon for some rapid prototyping in the Coordinator. The objective of this hackathon is to get proof of concept code for redeeming enrollment codes (aka 100% coupons) via an existing ecommerce system in our company called Titan.

This PR adds:
* Two API clients for Titan, one using OAuth (`TitanOAuthAPIClient`) and another using only an API key (`TitanAPIClient`).
* Wiring to the Celery task `enrollment_code_redemption_requested_create_order_task` to call the Titan `/redeemEnrollmentCode` endpoint using `TitanAPIClient`.
* A new Celery task called `enrollment_code_redemption_requested_create_order_oauth_task` that calls the Titan `/redeemEnrollmentCode` endpoint using `TitanOAuthAPIClient`.

This PR also:
* Renames a couple of parameters from https://github.com/edx/commerce-coordinator/pull/45
* Adds environmental variables for `TITAN_URL` and `TITAN_API_KEY`.
* Removes unnecessary configuration in devstack settings file.

## Additional information

* Jira: [REV-2847](https://2u-internal.atlassian.net/browse/REV-2847)
* Previous art: https://github.com/edx/commerce-coordinator/pull/44
* Draft sequence diagram:
    ```mermaid
    sequenceDiagram
        actor user as User
        participant lms as edX LMS
        participant ecommerce as edX Ecommerce
        participant frontend as Enrollment Page Frontend
        participant coordinator as edX Coordinator
        participant titan as Titan
        user->>frontend: GET {enrollment code URL}
        frontend->>+coordinator: POST /redeem_enrollment_code
        coordinator->>-titan: POST /redeemEnrollmentCode
        titan->>+coordinator: GET /checkEnrollmentCode
        coordinator->>+ecommerce: GET /coupons/check/[id]
        ecommerce-->>-coordinator: /coupons/check/[id] response
        coordinator-->>-titan: /checkEnrollmentCode response
        titan->>+coordinator: POST /fulfill
        coordinator->>ecommerce: POST /coupons/invalidate/[id]
        coordinator->>-lms: POST /api/enrollment/v1/enrollment
    ```
* Objective of this PR is to add the wiring for `coordinator->>-titan: POST /redeemEnrollmentCode` to happen in the Coordinator.

## Testing instructions

It is a known issue this PR has no tests. Tests will be created after the proof of concept hackathon.