### PR TITLE
fix: production requirements Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 .PHONY: help clean piptools requirements ci_requirements dev_requirements \
-        validation_requirements doc_requirements prod_requirements static shell \
+        validation_requirements doc_requirements production-requirements static shell \
         test coverage isort_check isort style lint quality pii_check validate \
         migrate html_coverage upgrade extract_translation dummy_translations \
         compile_translations fake_translations pull_translations \
@@ -50,7 +50,7 @@ validation_requirements: ## sync to requirements for testing & code quality chec
 doc_requirements:
 	pip-sync -q requirements/doc.txt
 
-prod_requirements: ## install requirements for production
+production-requirements: piptools ## install requirements for production
 	pip-sync -q requirements/production.txt
 
 static: ## generate static files


### PR DESCRIPTION
**Description:** We are adding the commerce coordinator to sandbox builds and Ansible task uses this Makefile target to install production requirements https://github.com/openedx/configuration/blob/1162f70ebf94c1af4b096476df2cecd234091671/playbooks/roles/edx_django_service/tasks/main.yml#L164

**JIRA:** https://2u-internal.atlassian.net/jira/software/c/projects/PSRE/boards/655?modal=detail&selectedIssue=PSRE-1830



**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
