### PR TITLE
feat: Add call to LMS Enrollment API

### DIFF
--- a/commerce_coordinator/apps/core/clients.py
+++ b/commerce_coordinator/apps/core/clients.py
@@ -2,6 +2,7 @@
 API client logic shared between plugins.
 """
 import logging
+from urllib.parse import urljoin
 
 from django.conf import settings
 from edx_rest_api_client.client import OAuthAPIClient
@@ -25,6 +26,43 @@ class Client:
             settings.REQUEST_CONNECT_TIMEOUT_SECONDS,
             settings.REQUEST_READ_TIMEOUT_SECONDS
         )
+
+    @staticmethod
+    def urljoin_directory(base_directory_url, relative_target_directory_url):
+        """
+        Adds relative_target_directory_url at the end of base_directory_url.
+
+        Supports inconsistent trailing slashes and chaining outputs to inputs.
+
+        A directory URL is one with an empty final path segment.
+
+        See RFC 3986 for definition of a path segment and a relative-path
+        reference.
+
+        Args:
+            base_directory_url: A directory URL, like
+                "http://example.com/directory/".
+            relative_target_directory_url: A relative-path reference of a
+                directory URL, like "subdirectory/".
+
+        Returns:
+            String. The expanded URL of relative_target_directory_url when
+            applied to base_directory_url.
+
+            If base_directory_url is "http://example.com/directory/" and
+            relative_target_directory_url is "subdirectory/", the returned
+            string is "http://example.com/directory/subdirectory/".
+
+            Will preserve both presence and absence of trailing slash in
+            relative_target_directory_url.
+        """
+        # Add slash at end of base_directory_url so relative_target_directory_url won't overwrite last path segment.
+        if not base_directory_url.endswith("/"):
+            base_directory_url += "/"
+        # Remove slash from start of relative_target_directory_url already present in base_directory_url.
+        if relative_target_directory_url.startswith("/"):
+            relative_target_directory_url = relative_target_directory_url[1:]
+        return urljoin(base_directory_url, relative_target_directory_url)
 
 
 class BaseEdxOAuthClient(Client):

--- a/commerce_coordinator/apps/core/serializers.py
+++ b/commerce_coordinator/apps/core/serializers.py
@@ -4,7 +4,7 @@ Serializers shared between plugins.
 from datetime import datetime
 
 from django.utils.translation import gettext_lazy as _
-from rest_framework.serializers import *
+from rest_framework.serializers import *  # pylint: disable=wildcard-import; this module extends DRF serializers
 
 
 class UnixDateTimeField(DateTimeField):

--- a/commerce_coordinator/apps/core/serializers.py
+++ b/commerce_coordinator/apps/core/serializers.py
@@ -1,0 +1,77 @@
+"""
+Serializers shared between plugins.
+"""
+from datetime import datetime
+
+from django.utils.translation import gettext_lazy as _
+from rest_framework.serializers import *
+
+
+class UnixDateTimeField(DateTimeField):
+    """
+    Serializer that accepts a POSIX time value.
+
+    POSIX time is a stricter variant of Unix time which does not count leap seconds.
+
+    Most Unix time values are already in POSIX time.
+
+    This class is a combination of DRF classes IntegerField and DateTimeField.
+    """
+    default_error_messages = {
+        'invalid_int': _('A valid integer is required.'),
+        'max_string_length': _('String value too large.'),
+        'unparsable_posix_timestamp': _('Could not parse POSIX timestamp.'),
+    }
+
+    MAX_STRING_LENGTH = 1000  # Guard against malicious string inputs.
+
+    def to_internal_value(self, value):
+        if isinstance(value, str) and len(value) > self.MAX_STRING_LENGTH:
+            self.fail('max_string_length')
+
+        try:
+            value = int(str(value))
+        except (ValueError, TypeError):
+            self.fail('invalid_int')
+
+        try:
+            value = datetime.fromtimestamp(value)
+        except (OverflowError, OSError):
+            # Typically restricted to years in 1970 through 2038.
+            # Will not catch Unix time stamps that count leap seconds.
+            self.fail('unparsable_posix_timestamp')
+
+        # Continue parsing as DateTimeField.
+        return super().to_internal_value(value)
+
+
+# The code in UnixDateTimeField was adapted from encode/django-rest-framework,
+# which requires the redistribution of the following BSD 3-Clause License:
+#
+# Copyright © 2011-present, [Encode OSS Ltd](https://www.encode.io/).
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/commerce_coordinator/apps/core/signal_helpers.py
+++ b/commerce_coordinator/apps/core/signal_helpers.py
@@ -25,9 +25,11 @@ def log_receiver(logger):
             try:
                 # Django's signal dispatcher will give the sender as a keyword argument
                 sender = kwargs['sender']
-                logger.info(f"{func.__name__} CALLED with sender '{sender}' and {kwargs}")
-                return func(*args, **kwargs)
+                result = func(*args, **kwargs)
+                logger.info(f"{func.__name__} CALLED with sender '{sender}' and {kwargs}, starting task {result}")
+                return result
             except Exception as e:
+                logger.info(f"{func.__name__} CALLED with sender '{sender}' and {kwargs}")
                 logger.exception(f"Something went wrong! Exception raised in {func.__name__} with error {repr(e)}")
                 raise e
         return wrapper
@@ -42,7 +44,7 @@ def format_signal_results(results):
     data = {}
     for receiver, response in results:
         receiver_name = receiver.__name__
-        exception_occurred = bool(response and response.__traceback__)
+        exception_occurred = bool(response and hasattr(response, "__traceback__"))
         if exception_occurred:
             response_str = traceback.format_exception(
                 type(response),

--- a/commerce_coordinator/apps/core/tests/test_clients.py
+++ b/commerce_coordinator/apps/core/tests/test_clients.py
@@ -1,0 +1,28 @@
+"""Test core.clients."""
+
+import ddt
+from django.test import TestCase
+
+from commerce_coordinator.apps.core.clients import Client
+
+
+@ddt.ddt
+class ClientTests(TestCase):
+    """Tests of the Client class."""
+
+    @ddt.data(
+        ("http://localhost:18130/directory", "/subdirectory"),
+        ("http://localhost:18130/directory", "/subdirectory/"),
+        ("http://localhost:18130/directory", "subdirectory"),
+        ("http://localhost:18130/directory", "subdirectory/"),
+        ("http://localhost:18130/directory/", "/subdirectory"),
+        ("http://localhost:18130/directory/", "/subdirectory/"),
+        ("http://localhost:18130/directory/", "subdirectory"),
+        ("http://localhost:18130/directory/", "subdirectory/"),
+
+    )
+    @ddt.unpack
+    def test_urljoin_directory_trailing_slashes(self, base, suffix):
+        output = Client().urljoin_directory(base, suffix)
+        expected = "http://localhost:18130/directory/subdirectory"
+        self.assertRegex(output, expected + r"/?")

--- a/commerce_coordinator/apps/core/tests/test_serializers.py
+++ b/commerce_coordinator/apps/core/tests/test_serializers.py
@@ -8,7 +8,6 @@ from django.test import TestCase
 
 from commerce_coordinator.apps.core import serializers
 
-
 utc = datetime.timezone.utc
 
 
@@ -40,4 +39,4 @@ class UnixDateTimeFieldTests(TestCase):
         with self.assertRaises(serializers.ValidationError) as exc_info:
             serializers.UnixDateTimeField().run_validation(input_value)
 
-        self.assertEquals(exc_info.exception.detail, expected_failure_message)
+        self.assertEqual(exc_info.exception.detail, expected_failure_message)

--- a/commerce_coordinator/apps/core/tests/test_serializers.py
+++ b/commerce_coordinator/apps/core/tests/test_serializers.py
@@ -1,0 +1,29 @@
+"""Test core.serializers."""
+
+import datetime
+
+import ddt
+from django.test import TestCase
+
+from commerce_coordinator.apps.core import serializers
+
+
+utc = datetime.timezone.utc
+
+
+@ddt.ddt
+class UnixDateTimeFieldTests(TestCase):
+    """Tests of UnixDateTimeField class."""
+
+    @ddt.data(
+        ("-1", datetime.datetime(1969, 12, 31, 23, 59, 59, tzinfo=utc)),
+        ("0", datetime.datetime(1970, 1, 1, 00, 00, tzinfo=utc)),
+        ("1680700901", datetime.datetime(2023, 4, 5, 13, 21, 41, tzinfo=utc)),
+        (1680700901, datetime.datetime(2023, 4, 5, 13, 21, 41, tzinfo=utc)),
+        (" 1680700901 ", datetime.datetime(2023, 4, 5, 13, 21, 41, tzinfo=utc)),
+    )
+    @ddt.unpack
+    def test_valid_values(self, input_value, expected_output):
+        """Check internal representation of UnixDateTimeField matches expected."""
+        output = serializers.UnixDateTimeField().run_validation(input_value)
+        self.assertEqual(output, expected_output)

--- a/commerce_coordinator/apps/core/tests/test_signal_helpers.py
+++ b/commerce_coordinator/apps/core/tests/test_signal_helpers.py
@@ -1,0 +1,240 @@
+"""Test core.signal_helpers."""
+
+import logging
+from pprint import pformat
+
+from django.apps import apps
+from django.test import TestCase, override_settings
+
+from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, format_signal_results, log_receiver
+
+# Log using module name.
+logger = logging.getLogger(__name__)
+
+# Fully qualified module name.
+fqmn = __name__
+
+# Test signal & receivers.
+mock_signal = CoordinatorSignal()
+
+
+@log_receiver(logger)
+def mock_receiver_1(**kwargs):
+    """No-op receiver that returns a bogus task id"""
+    return 'bogus_mock_receiver_1_task_id'
+
+
+@log_receiver(logger)
+def mock_receiver_2(**kwargs):
+    """No-op receiver that logs parameters and returns a bogus task id"""
+    param1 = kwargs['param1']
+    param2 = kwargs['param2']
+    logger.info(f'mock_receiver called with {param1}, {param2}')
+    return 'bogus_mock_receiver_2_task_id'
+
+
+@log_receiver(logger)
+def mock_receiver_exception(**kwargs):
+    """No-op receiver that raises an exception"""
+    raise RuntimeError('This is an expected exception.')
+
+
+@log_receiver(logger)
+def mock_receiver_innocent_bystander(**kwargs):
+    """No-op receiver that should never be called"""
+    raise RuntimeError('This receiver should never be set up or called.')
+
+
+class CoordinatorSignalTestCase(TestCase):
+    """Base class for testing CoordinatorSignal."""
+
+    def setUp(self):
+        # Initialize store for signal result.
+        self.result = None
+
+        # Initialize context manager for holding test logs.
+        self.logging_cm = None
+
+        # Clear receiver connections from previous tests.
+        mock_signal.receivers = []
+        mock_signal.sender_receivers_cache.clear()
+
+        # Remount signals after settings override.
+        apps.get_app_config('core').ready()
+
+        # Send mock_signal.
+        parameters = {
+            'param1': 'parameter1_value',
+            'param2': 'parameter2_value',
+        }
+
+        with self.assertLogs() as self.logging_cm:
+            self.result = mock_signal.send_robust(
+                sender=self.__class__,
+                **parameters
+            )
+
+
+@override_settings(
+    CC_SIGNALS={
+        fqmn + '.mock_signal': [
+            fqmn + '.mock_receiver_1',
+        ],
+    }
+)
+class CoordinatorSignalTests(CoordinatorSignalTestCase):
+    """Tests of CoordinatorSignal class."""
+
+    def test_config_matches_num_calls(self):
+        logger.info('self.result: %s', self.result)
+        self.assertEqual(len(self.result), 1,
+                         'Check 1 receiver is called')
+
+    def test_return_has_name_and_result(self):
+        logger.info('self.result: %s', self.result)
+        self.assertEqual(len(self.result[0]), 2,
+                         'Check receiver self.result has name and self.result')
+
+    def test_correct_receiver_called(self):
+        logger.info('self.result: %s', self.result)
+        self.assertEqual(self.result[0][0].__name__, 'mock_receiver_1',
+                         'Check receiver name is mock_receiver')
+
+    def test_correct_response_returned(self):
+        logger.info('self.result: %s', self.result)
+        self.assertEqual(self.result[0][1], 'bogus_mock_receiver_1_task_id',
+                         'Check reciever self.result is a task id')
+
+    def test_correct_arguments_passed(self):
+        logger.info('self.logging_cm.output: %s', self.logging_cm.output)
+        self.assertTrue(any('parameter1_value' in line for line in self.logging_cm.output),
+                        'Check parameter1_value is received by receiver')
+        self.assertTrue(any('parameter2_value' in line for line in self.logging_cm.output),
+                        'Check parameter2_value is received by receiver')
+
+    def test_exception_on_unrobust_send(self):
+        with self.assertRaises(NotImplementedError):
+            self.result = mock_signal.send(
+                sender=self.__class__
+            )
+
+
+@override_settings(
+    CC_SIGNALS={
+        fqmn + '.mock_signal': [
+            fqmn + '.mock_receiver_1',
+            fqmn + '.mock_receiver_2',
+            fqmn + '.mock_receiver_exception',
+        ],
+    }
+)
+class LogReceiverTests(CoordinatorSignalTestCase):
+    """Tests of log_receiver() helper function."""
+
+    def test_config_matches_num_calls(self):
+        logger.info('self.result: %s', self.result)
+        self.assertEqual(len(self.result), 3,
+                         'Check 3 receivers called')
+
+    def test_mock_receiver_exception_called(self):
+        logger.info('self.result: %s', self.result)
+        self.assertTrue(
+            any(
+                receiver.__name__ == 'mock_receiver_exception'
+                for receiver, response in self.result
+            ),
+            'Check mock_receiver_exception called'
+        )
+
+    def test_mock_receiver_exception_reported(self):
+        logger.info('self.result: %s', self.result)
+        self.assertTrue(
+            any(
+                receiver.__name__ == 'mock_receiver_exception'
+                and isinstance(response, RuntimeError)
+                for receiver, response in self.result
+            ),
+            'Check mock_receiver_exception reports its RuntimeError'
+        )
+
+    def test_mock_receiver_exception_logged(self):
+        logger.info('self.logging_cm.output: %s', self.logging_cm.output)
+        self.assertTrue(
+            any(
+                'This is an expected exception' in line
+                for line in self.logging_cm.output
+            ),
+            'Check mock_receiver_exception\'s RuntimeError is logged'
+        )
+
+
+@override_settings(
+    CC_SIGNALS={
+        fqmn + '.mock_signal': [
+            fqmn + '.mock_receiver_1',
+            fqmn + '.mock_receiver_2',
+            fqmn + '.mock_receiver_exception',
+        ],
+    }
+)
+class FormatSignalResultsTests(CoordinatorSignalTestCase):
+    """Tests of format_signal_results() helper function."""
+
+    def setUp(self):
+        super().setUp()
+
+        # Format results
+        self.formatted_result = format_signal_results(self.result)
+
+    def test_returns_dict(self):
+        logger.info('self.formatted_result: \n%s', pformat(self.formatted_result))
+        logger.info('type(self.formatted_result): %s', type(self.formatted_result))
+        self.assertIsInstance(self.formatted_result, dict,
+                              'Check output is a Python dict')
+
+    def test_config_matches_num_formatted_result_entries(self):
+        logger.info('self.formatted_result: \n%s', pformat(self.formatted_result))
+        self.assertEqual(len(self.formatted_result), 3,
+                         'Check 3 results are returned, one for each signal')
+
+    def test_formatted_result_shape(self):
+        logger.info('self.result: %s', self.result)
+        logger.info('self.formatted_result: \n%s', pformat(self.formatted_result))
+
+        for value in self.formatted_result.values():
+            self.assertIsInstance(value, dict,
+                                  'Check each output value is a dict')
+            self.assertIn('error', value.keys(),
+                          'Check dict for each output value has key called error')
+            self.assertIn('response', value.keys(),
+                          'Check dict for each output value has key called response')
+
+    def test_mock_receiver_1_result(self):
+        logger.info('self.result: %s', self.result)
+        logger.info('self.formatted_result: \n%s', pformat(self.formatted_result))
+
+        self.assertIn('mock_receiver_1', self.formatted_result,
+                      'Check results have entry for mock_receiver_1')
+
+        entry = self.formatted_result['mock_receiver_1']
+
+        self.assertFalse(entry['error'],
+                         'Check mock_receiver_1 reports no error')
+
+        self.assertEqual(entry['response'], 'bogus_mock_receiver_1_task_id',
+                         'Check mock_receiver_1 reports its return value')
+
+    def test_mock_receiver_exception_result(self):
+        logger.info('self.result: %s', self.result)
+        logger.info('self.formatted_result: \n%s', pformat(self.formatted_result))
+
+        self.assertIn('mock_receiver_exception', self.formatted_result,
+                      'Check results have entry for mock_receiver_exception')
+
+        entry = self.formatted_result['mock_receiver_exception']
+
+        self.assertTrue(entry['error'],
+                        'Check mock_receiver_exception reports an error')
+
+        self.assertTrue(any('RuntimeError' in line for line in entry['response']),
+                        'Check mock_receiver_exception contains RuntimeError info')

--- a/commerce_coordinator/apps/core/tests/test_signal_helpers.py
+++ b/commerce_coordinator/apps/core/tests/test_signal_helpers.py
@@ -39,12 +39,6 @@ def mock_receiver_exception(**kwargs):
     raise RuntimeError('This is an expected exception.')
 
 
-@log_receiver(logger)
-def mock_receiver_innocent_bystander(**kwargs):
-    """No-op receiver that should never be called"""
-    raise RuntimeError('This receiver should never be set up or called.')
-
-
 class CoordinatorSignalTestCase(TestCase):
     """Base class for testing CoordinatorSignal."""
 

--- a/commerce_coordinator/apps/ecommerce/clients.py
+++ b/commerce_coordinator/apps/ecommerce/clients.py
@@ -2,7 +2,6 @@
 API clients for ecommerce app.
 """
 import logging
-from urllib.parse import urljoin
 
 import requests
 from django.conf import settings
@@ -16,7 +15,11 @@ class EcommerceAPIClient(BaseEdxOAuthClient):
     """
     API client for calls to the edX Ecommerce service.
     """
-    api_base_url = urljoin(settings.ECOMMERCE_URL, '/api/v2')
+    api_base_url = ""
+
+    def __init__(self):
+        super().__init__()
+        self.api_base_url = self.urljoin_directory(settings.ECOMMERCE_URL, '/api/v2')
 
     def get_orders(self, query_params):
         """
@@ -31,7 +34,7 @@ class EcommerceAPIClient(BaseEdxOAuthClient):
 
         """
         try:
-            resource_url = urljoin(self.api_base_url, '/orders')
+            resource_url = self.urljoin_directory(self.api_base_url, '/orders')
             response = self.client.get(resource_url, params=query_params)
             response.raise_for_status()
             return response.json()

--- a/commerce_coordinator/apps/lms/clients.py
+++ b/commerce_coordinator/apps/lms/clients.py
@@ -1,8 +1,6 @@
 """
 API clients for LMS app.
 """
-from urllib.parse import urljoin
-
 import requests
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -23,7 +21,8 @@ class LMSAPIClient(BaseEdxOAuthClient):
         """
         Base URL for LMS Enrollment API service.
         """
-        return urljoin(settings.LMS_URL_ROOT, '/api/enrollment/v1/')
+        return self.urljoin_directory(settings.LMS_URL_ROOT, '/api/enrollment/v1/enrollment')
+
 
     def post(self, path, enrollment_data):
         """

--- a/commerce_coordinator/apps/lms/clients.py
+++ b/commerce_coordinator/apps/lms/clients.py
@@ -1,0 +1,47 @@
+"""
+API clients for LMS app.
+"""
+from urllib.parse import urljoin
+
+import requests
+from celery.utils.log import get_task_logger
+from django.conf import settings
+
+from commerce_coordinator.apps.core.clients import BaseEdxOAuthClient
+
+# Use special Celery logger for tasks client calls.
+logger = get_task_logger(__name__)
+
+
+class LMSAPIClient(BaseEdxOAuthClient):
+    """
+    API client for calls to the edX LMS service.
+    """
+
+    @property
+    def api_enrollment_base_url(self):
+        """
+        Base URL for LMS Enrollment API service.
+        """
+        return urljoin(settings.LMS_URL_ROOT, '/api/enrollment/v1/')
+
+    def post(self, path, enrollment_data):
+        """
+        Send a POST request to LMS Enrollment API endpoint
+        Arguments:
+            enrollment_data: dictionary to send to the API resource.
+        Returns:
+            dict: Dictionary represention of JSON returned from API
+        """
+        try:
+            enrollment_api_url = urljoin(self.api_enrollment_base_url, path)
+            response = self.client.post(
+                enrollment_api_url,
+                json=enrollment_data,
+                timeout=self.normal_timeout,
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as exc:
+            logger.error(exc)
+            raise

--- a/commerce_coordinator/apps/lms/signals.py
+++ b/commerce_coordinator/apps/lms/signals.py
@@ -15,12 +15,11 @@ def fulfill_order_placed_send_enroll_in_course(**kwargs):
     Fulfill the order placed in Titan with a Celery task to LMS to enroll a user in a single course.
     """
     fulfill_order_placed_send_enroll_in_course_task.delay(
-        coupon_code=kwargs['coupon_code'],
         course_id=kwargs['course_id'],
+        course_mode=kwargs['course_mode'],
         date_placed=kwargs['date_placed'],
         edx_lms_user_id=kwargs['edx_lms_user_id'],
-        edx_lms_username=kwargs['edx_lms_username'],
-        mode=kwargs['mode'],
-        partner_sku=kwargs['partner_sku'],
-        titan_order_uuid=kwargs['titan_order_uuid'],
+        email_opt_in=kwargs['email_opt_in'],
+        order_number=kwargs['order_number'],
+        provider_id=kwargs['provider_id'],
     )

--- a/commerce_coordinator/apps/lms/signals.py
+++ b/commerce_coordinator/apps/lms/signals.py
@@ -3,12 +3,10 @@ LMS app signals and receivers.
 """
 import logging
 
-from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
+from commerce_coordinator.apps.core.signal_helpers import log_receiver
 from commerce_coordinator.apps.lms.tasks import fulfill_order_placed_send_enroll_in_course_task
 
 logger = logging.getLogger(__name__)
-
-fulfill_order_placed_signal = CoordinatorSignal()
 
 
 @log_receiver(logger)

--- a/commerce_coordinator/apps/lms/tasks.py
+++ b/commerce_coordinator/apps/lms/tasks.py
@@ -59,5 +59,4 @@ def fulfill_order_placed_send_enroll_in_course_task(
             'value': provider_id,
         })
 
-    lms_api_client = LMSAPIClient()
-    return lms_api_client.post('enrollment', enrollment_data)
+    return LMSAPIClient().enroll_user_in_course(enrollment_data)

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -1,8 +1,6 @@
 """
 API clients for Titan.
 """
-from urllib.parse import urljoin
-
 import requests
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -27,7 +25,7 @@ class TitanAPIClient(Client):
     @property
     def api_base_url(self):
         """URL of API service."""
-        return urljoin(settings.TITAN_URL, '/api/edx/v1/')
+        return self.urljoin_directory(settings.TITAN_URL, '/api/edx/v1/')
 
     @property
     def api_key_header(self):
@@ -46,7 +44,7 @@ class TitanAPIClient(Client):
 
         """
         try:
-            resource_url = urljoin(self.api_base_url, resource_path)
+            resource_url = self.urljoin_directory(self.api_base_url, resource_path)
             response = self.client.post(
                 resource_url,
                 json=data,
@@ -78,7 +76,7 @@ class TitanAPIClient(Client):
 
         """
         try:
-            resource_url = urljoin(self.api_base_url, resource_path)
+            resource_url = self.urljoin_directory(self.api_base_url, resource_path)
             response = self.client.request(
                 method=request_method,
                 url=resource_url,

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -59,18 +59,23 @@ class TitanAPIClient(Client):
                 timeout=self.normal_timeout,
                 headers=headers,
             )
-            logger.debug('Response status: %s', response.status_code)
-            logger.debug('Request body: %s', response.request.body)
-            logger.debug('Request headers: %s', response.request.headers)
             response.raise_for_status()
             response_json = response.json()
+            logger.debug('Request URL: %s', response.request.url)
+            logger.debug('Request method: %s', response.request.method)
+            logger.debug('Request body: %s', response.request.body)
+            logger.debug('Request headers: %s', response.request.headers)
+            logger.debug('Response status: %s %s', response.status_code, response.reason)
             logger.debug('Response body: %s', response_json)
             return response_json
-        except requests.exceptions.HTTPError as exc:
+        except (requests.exceptions.HTTPError, requests.exceptions.JSONDecodeError) as exc:
             logger.error(exc)
-            logger.debug('Request method: %s', exc.request.method)
-            logger.debug('Request URL: %s', exc.request.url)
-            logger.debug('Request body: %s', exc.request.body)
+            logger.info('Request URL: %s', exc.request.url)
+            logger.info('Request method: %s', exc.request.method)
+            logger.info('Request body: %s', exc.request.body)
+            logger.debug('Request headers: %s', exc.request.headers)
+            logger.info('Response status: %s %s', exc.response.status_code, exc.response.reason)
+            logger.info('Response body: %s', exc.response.text)
             raise
 
     def create_order(self, edx_lms_user_id, email, first_name, last_name, currency='USD'):

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -85,8 +85,9 @@ class TitanAPIClient(Client):
                 timeout=self.normal_timeout,
                 headers=headers,
             )
-            logger.debug('response status: %s', response.status_code)
+            logger.debug('Response status: %s', response.status_code)
             logger.debug('Request body: %s', response.request.body)
+            logger.debug('Request headers: %s', response.request.headers)
             response.raise_for_status()
             response_json = response.json()
             logger.debug('Response body: %s', response_json)

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -25,7 +25,7 @@ class TitanAPIClient(Client):
     @property
     def api_base_url(self):
         """URL of API service."""
-        return self.urljoin_directory(settings.TITAN_URL, '/api/edx/v1/')
+        return self.urljoin_directory(settings.TITAN_URL, '/edx/api/v1/')
 
     @property
     def api_key_header(self):

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -117,9 +117,13 @@ class TitanAPIClient(Client):
             request_method='POST',
             resource_path='cart/add_item',
             json={
-                'orderUuid': order_uuid,
-                'courseSku': course_sku,
-            },
+                'data': {
+                    'attributes': {
+                        'orderUuid': order_uuid,
+                        'courseSku': course_sku,
+                        }
+                    }
+                },
         )
 
     def complete_order(self, order_uuid, edx_lms_user_id):

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -88,11 +88,15 @@ class TitanAPIClient(Client):
             request_method='POST',
             resource_path='cart',
             json={
-                'currency': currency,
-                'edxLmsUserId': edx_lms_user_id,
-                'email': email,
-                'firstName': first_name,
-                'lastName': last_name,
+                'data': {
+                    'attributes': {
+                        'currency': currency,
+                        'edxLmsUserId': edx_lms_user_id,
+                        'email': email,
+                        'firstName': first_name,
+                        'lastName': last_name,
+                    }
+                }
             },
         )
 

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -19,7 +19,7 @@ class TitanAPIClient(Client):
     def __init__(self):
         self.client = requests.Session()
         # Always send API key.
-        self.client.headers.update(self.api_key_header)
+        self.client.headers.update(self.api_base_header)
 
     @property
     def api_base_url(self):
@@ -27,10 +27,13 @@ class TitanAPIClient(Client):
         return self.urljoin_directory(settings.TITAN_URL, '/edx/api/v1/')
 
     @property
-    def api_key_header(self):
-        """Header to add as API key for requests."""
-        return {'X-Spree-API-Key': settings.TITAN_API_KEY}
-
+    def api_base_header(self):
+        """Header to add to all requests."""
+        return {
+            'Content-Type': 'application/vnd.api+json',
+            'User-Agent': '',
+            'X-Spree-API-Key': settings.TITAN_API_KEY,
+        }
 
     def _request(self, request_method, resource_path, params=None, json=None, headers=None):
         """
@@ -91,9 +94,6 @@ class TitanAPIClient(Client):
                 'firstName': first_name,
                 'lastName': last_name,
             },
-            headers={
-                'Content-Type': 'application/vnd.api+json'
-            },
         )
 
     def add_item(self, order_uuid, course_sku):
@@ -111,10 +111,6 @@ class TitanAPIClient(Client):
                 'orderUuid': order_uuid,
                 'courseSku': course_sku,
             },
-            headers={
-                'Content-Type': 'application/vnd.api+json'
-            },
-
         )
 
     def complete_order(self, order_uuid, edx_lms_user_id):

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -141,8 +141,12 @@ class TitanAPIClient(Client):
             request_method='POST',
             resource_path='checkout/complete',
             json={
-                'orderUuid': order_uuid,
-                'edxLmsUserId': edx_lms_user_id,
+                'data': {
+                    'attributes': {
+                        'orderUuid': order_uuid,
+                        'edxLmsUserId': edx_lms_user_id,
+                    }
+                }
             },
         )
 

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -89,6 +89,7 @@ class TitanAPIClient(Client):
             last_name: The edx.org profile last name of the user receiving the order
             currency: Optional. The ISO code of the currency to use for the order (defaults to USD)
         """
+        logger.info(f'TitanAPIClient.create_order called using {locals()}.')
         return self._request(
             request_method='POST',
             resource_path='cart',
@@ -113,6 +114,7 @@ class TitanAPIClient(Client):
             order_uuid: The UUID of the created order in Spree.
             course_sku: The SKU of the course being added to the order
         """
+        logger.info(f'TitanAPIClient.add_item called using {locals()}.')
         return self._request(
             request_method='POST',
             resource_path='cart/add_item',
@@ -134,6 +136,7 @@ class TitanAPIClient(Client):
             order_uuid: The UUID of the created order in Spree.
             edx_lms_user_id: The edx.org LMS user ID of the user receiving the order.
         """
+        logger.info(f'TitanAPIClient.complete_order called using {locals()}.')
         return self._request(
             request_method='POST',
             resource_path='checkout/complete',

--- a/commerce_coordinator/apps/titan/serializers.py
+++ b/commerce_coordinator/apps/titan/serializers.py
@@ -1,5 +1,5 @@
 """Serializers for Titan service"""
-from rest_framework import serializers
+from commerce_coordinator.apps.core import serializers
 
 
 class OrderFulfillViewInputSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -8,7 +8,7 @@ class OrderFulfillViewInputSerializer(serializers.Serializer):  # pylint: disabl
     """
     course_id = serializers.CharField(allow_null=False)
     course_mode = serializers.CharField(allow_null=False)
-    date_placed = serializers.DateTimeField(allow_null=False)
+    date_placed = serializers.UnixDateTimeField(allow_null=False)
     edx_lms_user_id = serializers.IntegerField(allow_null=False)
     email_opt_in = serializers.BooleanField(allow_null=False)
     order_number = serializers.UUIDField(allow_null=False)

--- a/commerce_coordinator/apps/titan/serializers.py
+++ b/commerce_coordinator/apps/titan/serializers.py
@@ -1,0 +1,15 @@
+"""Serializers for Titan service"""
+from rest_framework import serializers
+
+
+class OrderFulfillViewInputSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for OrderFulfillView input validation.
+    """
+    course_id = serializers.CharField(allow_null=False)
+    course_mode = serializers.CharField(allow_null=False)
+    date_placed = serializers.DateTimeField(allow_null=False)
+    edx_lms_user_id = serializers.IntegerField(allow_null=False)
+    email_opt_in = serializers.BooleanField(allow_null=False)
+    order_number = serializers.UUIDField(allow_null=False)
+    provider_id = serializers.CharField(allow_null=True)

--- a/commerce_coordinator/apps/titan/signals.py
+++ b/commerce_coordinator/apps/titan/signals.py
@@ -20,13 +20,14 @@ def enrollment_code_redemption_requested_create_order(**kwargs):
     """
     Create an order using the requested enrollment code.
     """
-    enrollment_code_redemption_requested_create_order_task.delay(
+    async_result = enrollment_code_redemption_requested_create_order_task.delay(
         kwargs['user_id'],
         kwargs['username'],
         kwargs['email'],
         kwargs['sku'],
         kwargs['coupon_code'],
     )
+    return async_result.id
 
 
 @log_receiver(logger)
@@ -34,7 +35,7 @@ def order_created_save(**kwargs):
     """
     Create an order.
     """
-    order_created_save_task.delay(
+    async_result = order_created_save_task.delay(
         kwargs['product_sku'],
         kwargs['edx_lms_user_id'],
         kwargs['email'],
@@ -42,3 +43,4 @@ def order_created_save(**kwargs):
         kwargs['last_name'],
         kwargs['coupon_code'],
     )
+    return async_result.id

--- a/commerce_coordinator/apps/titan/signals.py
+++ b/commerce_coordinator/apps/titan/signals.py
@@ -6,7 +6,6 @@ import logging
 
 from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
 from commerce_coordinator.apps.titan.tasks import (
-    enrollment_code_redemption_requested_create_order_oauth_task,
     enrollment_code_redemption_requested_create_order_task,
     order_created_save_task
 )
@@ -22,13 +21,6 @@ def enrollment_code_redemption_requested_create_order(**kwargs):
     Create an order using the requested enrollment code.
     """
     enrollment_code_redemption_requested_create_order_task.delay(
-        kwargs['user_id'],
-        kwargs['username'],
-        kwargs['email'],
-        kwargs['sku'],
-        kwargs['coupon_code'],
-    )
-    enrollment_code_redemption_requested_create_order_oauth_task.delay(
         kwargs['user_id'],
         kwargs['username'],
         kwargs['email'],

--- a/commerce_coordinator/apps/titan/tasks.py
+++ b/commerce_coordinator/apps/titan/tasks.py
@@ -5,7 +5,7 @@ Titan Celery tasks
 from celery import shared_task
 from celery.utils.log import get_task_logger
 
-from .clients import TitanAPIClient, TitanOAuthAPIClient
+from .clients import TitanAPIClient
 
 # Use the special Celery logger for our tasks
 logger = get_task_logger(__name__)
@@ -28,47 +28,8 @@ def enrollment_code_redemption_requested_create_order_task(user_id, username, em
                 f'sku {sku} and coupon code {coupon_code}.')
 
     titan_api_client = TitanAPIClient()
-    titan_api_client.post(
-        '/enrollment-code-redemptions',
-        {
-            'source': 'edx',
-            'productSku': sku,
-            'couponCode': coupon_code,
-            'edxLmsUserId': user_id,
-            'edxLmsUserName': username,
-            'email': email,
-        }
-    )
 
-
-@shared_task()
-def enrollment_code_redemption_requested_create_order_oauth_task(user_id, username, email, sku, coupon_code):
-    """
-    Ask to create an order to redeeem an enrollment code.
-
-    Args:
-        user_id: edX LMS user id redeeming enrollment code
-        username: edX LMS username of user_id
-        email: edX LMS user email of user_id
-        sku: ecommerce partner_sku of product to redeem
-        coupon_code: enrollment code
-    """
-    logger.info('Titan enrollment_code_redemption_requested_create_order_oauth_task fired '
-                f'with user {user_id}, username {username}, email {email}, '
-                f'sku {sku} and coupon code {coupon_code}.')
-
-    titan_api_client = TitanOAuthAPIClient()
-    titan_api_client.post(
-        '/enrollment-code-redemptions',
-        {
-            'source': 'edx',
-            'productSku': sku,
-            'couponCode': coupon_code,
-            'edxLmsUserId': user_id,
-            'edxLmsUserName': username,
-            'email': email,
-        }
-    )
+    titan_api_client.redeem_enrollment_code(sku, coupon_code, user_id, username, email)
 
 
 @shared_task()

--- a/commerce_coordinator/apps/titan/tasks.py
+++ b/commerce_coordinator/apps/titan/tasks.py
@@ -58,7 +58,7 @@ def order_created_save_task(product_sku, edx_lms_user_id, email, first_name, las
     order_created_response = titan_api_client.create_order(
         edx_lms_user_id, email, first_name, last_name
     )
-    order_uuid = order_created_response['uuid']
+    order_uuid = order_created_response['data']['attributes']['uuid']
 
     # Adding courses in Cart/Basket
     for sku in product_sku:

--- a/commerce_coordinator/apps/titan/tests/test_clients.py
+++ b/commerce_coordinator/apps/titan/tests/test_clients.py
@@ -43,7 +43,7 @@ class TestTitanAPIClient(TestCase):
 
     def _mock_create_order(self, status=200):
         """Does required mocking for create order API"""
-        url = urljoin(TITAN_URL, 'api/edx/v1/cart')
+        url = urljoin(TITAN_URL, 'edx/api/v1/cart')
         body = json.dumps(
             {
                 'uuid': self.order_uuid,
@@ -71,7 +71,7 @@ class TestTitanAPIClient(TestCase):
         with LogCapture(LOGGER_NAME) as logger:
             response = self.client.create_order(**self.order_create_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'response status: 200'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 200'),
             )
         self.assertEqual(response['uuid'], self.order_uuid)
         request = responses.calls[-1].request
@@ -84,14 +84,14 @@ class TestTitanAPIClient(TestCase):
             with pytest.raises(HTTPError):
                 self.client.create_order(**self.order_create_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'response status: 400'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 400'),
             )
         request = responses.calls[-1].request
         self._assert_order_create_request(request)
 
     def _mock_add_item(self, status=200):
         """add required mocking for add_item API"""
-        url = urljoin(TITAN_URL, 'api/edx/v1/cart/add_item')
+        url = urljoin(TITAN_URL, 'edx/api/v1/cart/add_item')
         body = json.dumps(
             {
                 'uuid': self.order_uuid,
@@ -111,7 +111,7 @@ class TestTitanAPIClient(TestCase):
         with LogCapture(LOGGER_NAME) as logger:
             response = self.client.add_item(**self.add_item_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'response status: 200'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 200'),
             )
         self.assertEqual(response['uuid'], self.order_uuid)
         request = responses.calls[-1].request
@@ -124,14 +124,14 @@ class TestTitanAPIClient(TestCase):
             with pytest.raises(HTTPError):
                 self.client.add_item(**self.add_item_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'response status: 400'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 400'),
             )
         request = responses.calls[-1].request
         self._assert_add_item_request(request)
 
     def _mock_order_complete(self, status=200):
         """add required mocking for complete API"""
-        url = urljoin(TITAN_URL, 'api/edx/v1/checkout/complete')
+        url = urljoin(TITAN_URL, 'edx/api/v1/checkout/complete')
         body = json.dumps(
             {
                 'uuid': self.order_uuid,
@@ -151,7 +151,7 @@ class TestTitanAPIClient(TestCase):
         with LogCapture(LOGGER_NAME) as logger:
             response = self.client.complete_order(**self.order_complete_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'response status: 200'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 200'),
             )
         self.assertEqual(response['uuid'], self.order_uuid)
         request = responses.calls[-1].request
@@ -164,7 +164,7 @@ class TestTitanAPIClient(TestCase):
             with pytest.raises(HTTPError):
                 self.client.complete_order(**self.order_complete_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'response status: 400'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 400'),
             )
         request = responses.calls[-1].request
         self._assert_complete_order_request(request)

--- a/commerce_coordinator/apps/titan/tests/test_clients.py
+++ b/commerce_coordinator/apps/titan/tests/test_clients.py
@@ -71,7 +71,7 @@ class TestTitanAPIClient(TestCase):
         with LogCapture(LOGGER_NAME) as logger:
             response = self.client.create_order(**self.order_create_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'Response status: 200'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 200 OK'),
             )
         self.assertEqual(response['uuid'], self.order_uuid)
         request = responses.calls[-1].request
@@ -84,7 +84,7 @@ class TestTitanAPIClient(TestCase):
             with pytest.raises(HTTPError):
                 self.client.create_order(**self.order_create_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'Response status: 400'),
+                (LOGGER_NAME, 'INFO', 'Response status: 400 Bad Request'),
             )
         request = responses.calls[-1].request
         self._assert_order_create_request(request)
@@ -111,7 +111,7 @@ class TestTitanAPIClient(TestCase):
         with LogCapture(LOGGER_NAME) as logger:
             response = self.client.add_item(**self.add_item_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'Response status: 200'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 200 OK'),
             )
         self.assertEqual(response['uuid'], self.order_uuid)
         request = responses.calls[-1].request
@@ -124,7 +124,7 @@ class TestTitanAPIClient(TestCase):
             with pytest.raises(HTTPError):
                 self.client.add_item(**self.add_item_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'Response status: 400'),
+                (LOGGER_NAME, 'INFO', 'Response status: 400 Bad Request'),
             )
         request = responses.calls[-1].request
         self._assert_add_item_request(request)
@@ -151,7 +151,7 @@ class TestTitanAPIClient(TestCase):
         with LogCapture(LOGGER_NAME) as logger:
             response = self.client.complete_order(**self.order_complete_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'Response status: 200'),
+                (LOGGER_NAME, 'DEBUG', 'Response status: 200 OK'),
             )
         self.assertEqual(response['uuid'], self.order_uuid)
         request = responses.calls[-1].request
@@ -164,7 +164,7 @@ class TestTitanAPIClient(TestCase):
             with pytest.raises(HTTPError):
                 self.client.complete_order(**self.order_complete_data)
             logger.check_present(
-                (LOGGER_NAME, 'DEBUG', 'Response status: 400'),
+                (LOGGER_NAME, 'INFO', 'Response status: 400 Bad Request'),
             )
         request = responses.calls[-1].request
         self._assert_complete_order_request(request)

--- a/commerce_coordinator/apps/titan/tests/test_clients.py
+++ b/commerce_coordinator/apps/titan/tests/test_clients.py
@@ -58,7 +58,7 @@ class TestTitanAPIClient(TestCase):
     def _assert_order_create_request(self, request):
         """Assert request."""
         self._assert_request_headers(request.headers)
-        request_body = json.loads(request.body)
+        request_body = json.loads(request.body)['data']['attributes']
         self.assertEqual(request_body['currency'], 'USD')
         self.assertEqual(request_body['edxLmsUserId'], self.order_create_data['edx_lms_user_id'])
         self.assertEqual(request_body['email'], self.order_create_data['email'])
@@ -101,7 +101,7 @@ class TestTitanAPIClient(TestCase):
 
     def _assert_add_item_request(self, request):
         self._assert_request_headers(request.headers)
-        request_body = json.loads(request.body)
+        request_body = json.loads(request.body)['data']['attributes']
         self.assertEqual(request_body['orderUuid'], self.add_item_data['order_uuid'])
         self.assertEqual(request_body['courseSku'], self.add_item_data['course_sku'])
 
@@ -141,7 +141,7 @@ class TestTitanAPIClient(TestCase):
 
     def _assert_complete_order_request(self, request):
         self._assert_request_headers(request.headers)
-        request_body = json.loads(request.body)
+        request_body = json.loads(request.body)['data']['attributes']
         self.assertEqual(request_body['orderUuid'], self.order_complete_data['order_uuid'])
         self.assertEqual(request_body['edxLmsUserId'], self.order_complete_data['edx_lms_user_id'])
 

--- a/commerce_coordinator/apps/titan/tests/test_tasks.py
+++ b/commerce_coordinator/apps/titan/tests/test_tasks.py
@@ -11,7 +11,11 @@ ORDER_UUID = 'test-uuid'
 class TitanClientMock(MagicMock):
     """A mock EcommerceAPIClient that always returns ECOMMERCE_REQUEST_EXPECTED_RESPONSE."""
     return_value = {
-        'uuid': ORDER_UUID,
+        'data': {
+            'attributes': {
+                'uuid': ORDER_UUID,
+            },
+        },
     }
 
 

--- a/commerce_coordinator/apps/titan/views.py
+++ b/commerce_coordinator/apps/titan/views.py
@@ -53,6 +53,9 @@ class OrderFulfillView(APIView):
 
             }
         """
+        logger.debug(f'Titan OrderFulfillView.post() request object: {request.data}.')
+        logger.debug(f'Titan OrderFulfillView.post() headers: {request.headers}.')
+
         params = {
             'course_id': request.data.get('course_id'),
             'course_mode': request.data.get('course_mode'),

--- a/commerce_coordinator/apps/titan/views.py
+++ b/commerce_coordinator/apps/titan/views.py
@@ -4,6 +4,7 @@ Views for the titan app
 
 import logging
 
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
@@ -21,6 +22,7 @@ class OrderFulfillView(APIView):
     """
     API for order fulfillment that is called from Titan.
     """
+    parser_classes = [JSONParser]
     permission_classes = [IsAdminUser]
     throttle_classes = [UserRateThrottle]
 

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -243,6 +243,9 @@ EXTRA_SCOPE = ['permissions']
 # TODO Set this to another (non-staff, ideally) path.
 LOGIN_REDIRECT_URL = '/admin/'
 
+# Set legacy credentials to access edX services.
+EDX_API_KEY = 'replace-me'
+
 # Set token credentials for non-edX services.
 TITAN_API_KEY = 'replace-me'
 
@@ -308,6 +311,9 @@ CC_SIGNALS = {
 # (See https://docs.python-requests.org/en/master/user/advanced/#timeouts for more info.)
 REQUEST_CONNECT_TIMEOUT_SECONDS = 3.05
 REQUEST_READ_TIMEOUT_SECONDS = 5
+
+# Special timeout for fulfillment
+FULFILLMENT_TIMEOUT = 7
 
 # API URLs
 ECOMMERCE_URL = 'replace-me'

--- a/commerce_coordinator/settings/devstack.py
+++ b/commerce_coordinator/settings/devstack.py
@@ -61,3 +61,9 @@ CELERY_BROKER_URL = "redis://:password@edx.devstack.redis:6379/0"
 # Application URLs in devstack.
 ECOMMERCE_URL = "http://edx.devstack.ecommerce:18130"
 TITAN_URL = os.environ.get('TITAN_URL_ROOT', 'http://titan_titan-app_1:3000')
+
+# Set legacy credentials to access edX services.
+EDX_API_KEY = 'PUT_YOUR_API_KEY_HERE'  # This is the actual API key in devstack.
+
+# Special timeout for fulfillment.
+FULFILLMENT_TIMEOUT = 15  # Devstack is slow!

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -107,6 +107,8 @@ LOGGING = get_logger_config(debug=DEBUG)
 
 CELERY_BROKER_URL = "redis://:password@localhost:6379/0"
 
+EDX_API_KEY = 'PUT_YOUR_API_KEY_HERE'  # This is the actual API key in devstack.
+
 ECOMMERCE_URL = "http://localhost:18130"
 
 LMS_URL_ROOT = "http://localhost:18000"
@@ -114,6 +116,8 @@ LMS_URL_ROOT = "http://localhost:18000"
 TITAN_URL = "http://example.com"
 
 TITAN_OAUTH2_PROVIDER_URL = "http://example.com"
+
+FULFILLMENT_TIMEOUT = 15  # Devstack is slow!
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -109,6 +109,8 @@ CELERY_BROKER_URL = "redis://:password@localhost:6379/0"
 
 ECOMMERCE_URL = "http://localhost:18130"
 
+LMS_URL_ROOT = "http://localhost:18000"
+
 TITAN_URL = "http://example.com"
 
 TITAN_OAUTH2_PROVIDER_URL = "http://example.com"


### PR DESCRIPTION
## Description

### Fulfillment

This PR adds a POST call to https://courses.edx.org/api/enrollment/v1/enrollment on call of signal `commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course`.

This allows other systems to enroll a user in a course.

The implementation looks like this:

```mermaid
flowchart TB
subgraph Fulfillment
    direction TB
    commerce_coordinator.apps.lms.clients.LmsAPIClient.enroll_user_in_course --> commerce_coordinator.apps.lms.clients.https://courses.edx.org/api/enrollment/v1/enrollment::POST
    commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course --> commerce_coordinator.apps.lms.tasks.fulfill_order_placed_send_enroll_in_course_task
    commerce_coordinator.apps.lms.tasks.fulfill_order_placed_send_enroll_in_course_task --> commerce_coordinator.apps.lms.clients.LmsAPIClient.enroll_user_in_course
end
```

See:

- 5566291 feat: Add call to LMS Enrollment API
- 304d517 fix: update parameters for order fulfillment & add serializer
- 5f47311 fix: configure LMSAPIClient.enroll_user_in_course()


### Order Details

This PR also edits the Order Detail calls to Titan in `clients.py` to reflect API changes.

See:

- 050c558 fix: correct titan api_base_url from /api/edx to /edx/api
  - 700d366 test: correct urljoin & logging name
- 0b9a795 feat: send User-Agent header with TitanAPIClient
- Adding data.attributes:
  - 008e87d fix: nest output of titan /cart in json field data.attributes
  - e7c730e fix: /cart json response: use data.attributes.uuid, not uuid
  - 68bdd2b fix: /cart/add_item json response: send output nested in a data.attributes json dict
  - fb69ce2 fix: /cart/complete json response: send output nested in a data.attributes json dict
  - e01df3c test: expect response from titan to be wrapped in data.attributes
- d57deb1 fix: force JSON parser for Titan's OrderFulfillView


### Other improvements

Add a helper function for combining URLs together without worrying about trailing or leading slashes:

- b5504af refactor: urljoin_directory() helper for combining urls

Return Celery task id:

- 5a4ea87 feat: send created celery task id on Titan tasks.py start
  - [ ] TODO: Send task id back to Titan in clients.py

Improve testing: add `CoordinatorSignalTestCase`:
 
- 8a0f0c2 test: add core/tests/test_signal_helpers.py

Create tooling to accept Unix timestamps:

- 4fa7f92 feat: add UnixDateTimeField DRF serializer field
  - 0da0bad fix: use UnixDateTimeField with OrderFulfillViewInputSerializer
  - 4b4f7bb test: add UnixDateTimeFieldTests failure cases
- 5145b06 docs: allow wildcard-import of core/serializers.py

Cleanup:

- 53dfc49 refactor: remove duplicate fulfill_order_placed_signal CoordinatorSignal
- 003f50c fix: deprecate TitanOAuthAPIClient and TitanAPIClient.post()

Improve logging:

- 98ae36d fix: add debug logging of request headers
- 3350758 fix: improve titan/clients.py logging
- af7c249 fix: add logging when each TitanAPIClient is called
- 1babee6 chore: add debug logging for request/response


## Additional Information

* Jira:
  * [THES-90](https://2u-internal.atlassian.net/browse/THES-90) Order Detail: Add header, update TITAN_URL, and nest input parameters under data.attributes
  * [THES-92](https://2u-internal.atlassian.net/browse/THES-92) Flow - Fulfillment: Step 2 - Finish adding all Connections for Fulfillment Flow to Coordinator


## Testing Instructions

### Setup

Tested locally and in Theseus Demo Sandbox.

First, re-provision Coordinator to set up the `titan_worker` user in LMS and Ecommerce:

https://github.com/edx/commerce-coordinator/blob/03df2887942838db9608c2d755bbb01af8f2a77c/README.rst?plain=1#L67

Next, register a new user. Note their LMS user id in http://localhost:18000/admin/auth/user/.

Go to http://localhost:8140/orders/order_history/ while logged in as that user to register them with Coordinator.[^1] 

Add the following waffle flags to Ecommerce at http://localhost:18130/admin/waffle/flag/. (You may have to access http://localhost:18130/login.):
* transition_to_coordinator.order_create
* transition_to_coordinator.fulfillment

### Order Details (Ecommerce → Coordinator → Titan)

Get `ecommerce_worker` user's JWT token:

    curl "http://localhost:18000/oauth2/access_token" \
        --data grant_type=client_credentials \
        --data client_id=ecommerce-backend-service-key \
        --data client_secret=ecommerce-backend-service-secret \
        --data token_type=jwt \
    | jq -r '"Authorization: JWT " + .access_token' \
    > /tmp/local_ecommerce_worker_access_token

Simulate call from Ecommerce using `ecommerce_worker`, replacing `edx_lms_user_id=12` with the LMS user id you created earlier:

    curl --get "http://localhost:8140/ecommerce/order/" \
        --data edx_lms_user_id=12 \
        --data-urlencode email=pshiu+local-test-1@example.com \
        --data first_name=John \
        --data last_name=Doe \
        --data product_sku=DEAA967 \
        --header @/tmp/local_ecommerce_worker_access_token

You should see requests to Titan's `/cart`, `/cart/add_item`, and `/cart/complete` endpoints.

### Fulfillment (Titan → Coordinator → LMS)

Get `titan_worker` user's JWT token:

    curl "http://localhost:18000/oauth2/access_token" \
        --data grant_type=client_credentials \
        --data client_id=titan-backend-service-key \
        --data client_secret=titan-backend-service-secret \
        --data token_type=jwt \
    | jq -r '"Authorization: JWT " + .access_token' \
    > /tmp/local_titan_worker_access_token

Simulate call from Titan using `titan_worker`, replacing `edx_lms_user_id=12` with the LMS user id you created earlier:

    curl "http://localhost:8140/titan/fulfill/" \
        --json '{
            "course_mode": "verified",
            "edx_lms_user_id": 12,
            "email_opt_in": false,
            "order_number": "5b910f41-9f74-44cc-ab6d-d10b172fbc4f",
            "order_placed": 1680720945,
            "course_id": "course-v1:edX+DemoX+Demo_Course"
        }' \
        --header @/tmp/local_titan_worker_access_token

You should see requests to LMS's fulfillment endpoints.


[^1]: This is required for the user's LMS ID to make its way into the Coordinator. In the future, users will be visiting the Coordinator using the /basket endpoint from Ecommerce, so their LMS ID will already be in the system—this is just a testing workaround while we are not done with MS2 yet.