### PR TITLE
Updates for Docker Provisioning, And first attempt at Titan support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,12 @@ validate_translations: fake_translations detect_changed_source_translations ## i
 docker_build:
 	docker build . -f Dockerfile -t openedx/commerce-coordinator
 
+dev.provision_docker: # start LMS, and Setup a clean commerce-coordinator stack. You will need to start titan yourself.
+	bash provision-commerce-coordinator.sh
+
+dev.run_test_query:
+	curl  http://localhost:8140/demo_lms/test/
+
 # devstack-themed shortcuts
 dev.up: # Starts all containers
 	docker-compose up -d
@@ -161,6 +167,21 @@ dev.down: # Kills containers and all of their data that isn't in volumes
 
 dev.stop: # Stops containers so they can be restarted
 	docker-compose stop
+
+dev.multistack.up:
+	docker compose -p titan up
+	bash find-start-lms.sh
+	docker-compose up -d --build
+
+dev.multistack.stop:
+	docker compose -p titan stop
+	docker compose -p devstack stop
+	docker compose stop
+
+dev.multistack.start:
+	docker compose -p titan start
+	bash find-start-lms.sh
+	docker compose start
 
 app-shell: # Run the app shell as root
 	docker exec -u 0 -it commerce-coordinator.app bash

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,9 @@ Initial Setup: steps and confirmation
 
 Note: this setup process is temporary; we will be working on a Tutor plugin
 
+Local
+======
+
 .. code-block::
 
   # Clone the repository
@@ -127,6 +130,17 @@ Local testing with Celery
   "<function demo_purchase_complete_enroll_in_course at 0x10e18a670>": ""
  }
 
+With Docker
+===========
+
+1. First start Titan (if you have it)
+2. Execute `make dev.provision_docker`
+
+> Note: This will attempt to connect to LMS and create the required superusers, please ensure you have the edX devstack setup first.
+
+After you can manage the stack by calling `make dev.up`, `make dev.down` (delete) or `make dev.stop`.
+
+As of the time of this writing, you must have run `make dev.up.ecommerce+lms+redis` in edX's devstack as a prerequisite to this one.
 
 License
 *******

--- a/commerce_coordinator/settings/devstack.py
+++ b/commerce_coordinator/settings/devstack.py
@@ -23,4 +23,4 @@ CELERY_BROKER_URL = "redis://:password@edx.devstack.redis:6379/0"
 
 # Application URLs in devstack.
 ECOMMERCE_URL = "http://edx.devstack.ecommerce:18130"
-TITAN_URL = "http://localhost/replace-me"
+TITAN_URL = os.environ.get('TITAN_URL_ROOT', 'http://titan_titan-app_1:3000')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,20 @@
 version: "2.1"
 services:
   db:
-    image: mysql:5.6
+    image: edxops/mysql:5.7
     container_name: commerce-coordinator.db
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    networks:
-      - devstack_default
     volumes:
       - commerce-coordinator_mysql:/var/lib/mysql
 
   memcache:
-    image: memcached:1.4.24
+    image: memcached:1.5.10-alpine
     container_name: commerce-coordinator.memcache
 
   app:
-    # Uncomment this line to use the official commerce-coordinator base image
     image: openedx/commerce-coordinator
-
     container_name: commerce-coordinator.app
     volumes:
       - .:/edx/app/commerce-coordinator/
@@ -27,13 +23,20 @@ services:
       DJANGO_SETTINGS_MODULE: commerce_coordinator.settings.devstack
     ports:
       - "8140:8140"
-    networks:
-      - devstack_default
     stdin_open: true
     tty: true
+    depends_on:
+      - "db"
+    networks:
+      - devstack_default # edX Dev Stack
+      - titan_default    # GetSmarter Titan
+      - default          # Just these containers
 
 networks:
+  default:
   devstack_default:
+    external: true
+  titan_default:
     external: true
 
 volumes:

--- a/find-start-lms.sh
+++ b/find-start-lms.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+#
+# The purpose of this script is to find the location of your local edX DevStack 
+# and to start up the required services of the LMS and Ecomm for Commerce Coordinator
+#
+# This script honors an incomming (exported) `DEVSTACK_WORKSPACE` EnvVar to target 
+# LMS in unusual layouts, just as the LMS Makefile does.
+#
+
+RED="\x1B[31m"
+GREEN="\x1B[32m"
+NC="\x1B[0m"
+
+# This repo is expected to be in the same folder as all openedx projects are.
+# This varible is local to this script and is not exported as to both neither
+# impack the executing shell, but allow for overrides in the standard way
+# used by edx-platform developers in their own environbments. 
+if [ -z ${DEVSTACK_WORKSPACE+x} ]; then DEVSTACK_WORKSPACE=$(pwd)/..; fi
+
+
+if [ ! -d "${DEVSTACK_WORKSPACE}/devstack" ]; then
+    echo -e "${RED}Cannot find location of openedx/devstack, please set DEVSTACK_WORKSPACE to devstack's parent directory.'${NC}"
+    exit 1
+fi
+
+
+if [ "$( docker ps -a | grep -c edx.devstack.lms )" -gt 0 ]; then
+    echo -e "${GREEN}Ensuring LMS is up.${NC}"
+    pushd "${DEVSTACK_WORKSPACE}/devstack" || exit # directory mysteriously disappeared
+    make dev.up.ecommerce+lms+redis
+
+    echo "Waiting for LMS MySQL"
+    until docker exec -i edx.devstack.mysql57 mysql -u root -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
+    do
+      printf "."
+      sleep 1
+    done
+    echo -e ""
+
+    popd || exit # original directory mysteriously disappeared
+else
+    echo -e "${RED}LMS Docker Container is Missing, and is required, please compose the openedx devstack first${NC}"
+    exit 1
+fi

--- a/provision-commerce-coordinator.sh
+++ b/provision-commerce-coordinator.sh
@@ -1,36 +1,61 @@
+#!/usr/bin/env bash
+
 name="commerce-coordinator"
 port="8140"
 
+RED="\x1B[31m"
+GREEN="\x1B[32m"
+NC="\x1B[0m"
+
+bash ./find-start-lms.sh
+
+docker-compose down -v # its ok if this fails.
 docker-compose up -d --build
 
 # Install requirements
 # Can be skipped right now because we're using the --build flag on docker-compose. This will need to be changed once we move to devstack.
 
 # Wait for MySQL
-echo "Waiting for MySQL"
+echo "Waiting for ${name} MySQL"
 until docker exec -i commerce-coordinator.db mysql -u root -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
 do
   printf "."
   sleep 1
 done
 sleep 5
+echo -e ""
 
 # Create the database
-docker exec -i commerce-coordinator.db mysql -u root -se "CREATE DATABASE commerce-coordinator;"
+
+docker exec -i commerce-coordinator.db mysql -u root -se 'CREATE DATABASE `commerce-coordinator`;'
 
 # Run migrations
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
-docker exec -t commerce-coordinator.app bash -c "cd /edx/app/${name}/ && make migrate"
+docker exec -t commerce-coordinator.app bash -c "cd /edx/app/${name}/ && python manage.py migrate"
 
 # Create superuser
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
-docker exec -t commerce-coordinator.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${name}/manage.py shell"
+docker exec -i commerce-coordinator.app bash  << EOS
+    python /edx/app/${name}/manage.py shell << EOIS
+from django.contrib.auth import get_user_model;
+User = get_user_model();
+User.objects.create_superuser("edx", "edx@example.com", "edx") if not User.objects.filter(username="edx").exists() else None;
+EOIS
+EOS
 
-# Provision IDA User in LMS
+lms_exec() {
+    docker exec -t edx.devstack.lms  bash -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker ${*}"
+}
+
+
+# Provision IDA User in LMS (https://2u-internal.atlassian.net/wiki/spaces/SRE/pages/19267432/Setup+OAuth+Client+and+JWT+for+Internal+Services+Django+Oauth+Toolkit+version)
 echo -e "${GREEN}Provisioning ${name}_worker in LMS...${NC}"
-	@@ -34,5 +13,3 @@ docker exec -t edx.devstack.lms  bash -c "source /edx/app/edxapp/edxapp_env && p
-docker exec -t edx.devstack.lms  bash -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type authorization-code --skip-authorization --redirect-uris 'http://localhost:${port}/complete/edx-oauth2/' --client-id '${name}-sso-key' --client-secret '${name}-sso-secret' --scopes 'user_id' ${name}-sso ${name}_worker"
-docker exec -t edx.devstack.lms bash -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type client-credentials --client-id '${name}-backend-service-key' --client-secret '${name}-backend-service-secret' ${name}-backend-service ${name}_worker"
+lms_exec "manage_user ${name}_worker ${name}_worker@example.com --staff --superuser"
+lms_exec "create_dot_application --grant-type authorization-code --skip-authorization --redirect-uris 'http://localhost:${port}/complete/edx-oauth2/' --client-id '${name}-sso-key' --client-secret '${name}-sso-secret' --scopes 'user_id' ${name}-sso ${name}_worker"
+lms_exec "create_dot_application --grant-type client-credentials --client-id '${name}-backend-service-key' --client-secret '${name}-backend-service-secret' ${name}-backend-service ${name}_worker"
+
+echo -e "${GREEN}Processing static files...${NC}"
+docker exec -i commerce-coordinator.app bash -c "python /edx/app/${name}/manage.py collectstatic"
 
 # Restart enterprise.catalog app and worker containers
 docker-compose restart app


### PR DESCRIPTION
# Updates for Docker Provisioning, As well as first attempt at Titan support.

- `provision-commerce-coordinator.sh` now creates the full Docker stack.
- `docker-compose.yml` modified to support devstack and titan networks.
- `commerce_coordinator/settings/devstack.py` now points to the default instance name for the titan application (though im unsure if the path is correct), can be configured via EnvVar
- `Makefile` changes for provisioning as well as manual orchestration of the 3 stacks.

