### PR TITLE
Removal of Titan requirements to build a composition CC…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ validate_translations: fake_translations detect_changed_source_translations ## i
 docker_build:
 	docker build . -f Dockerfile -t openedx/commerce-coordinator
 
-dev.provision_docker: # start LMS, and Setup a clean commerce-coordinator stack. You will need to start titan yourself.
+dev.provision_docker: # start LMS, and Setup a clean commerce-coordinator stack.
 	bash provision-commerce-coordinator.sh
 
 dev.run_test_query:
@@ -169,17 +169,14 @@ dev.stop: # Stops containers so they can be restarted
 	docker-compose stop
 
 dev.multistack.up:
-	docker compose -p titan up
 	bash find-start-lms.sh
 	docker-compose up -d --build
 
 dev.multistack.stop:
-	docker compose -p titan stop
 	docker compose -p devstack stop
 	docker compose stop
 
 dev.multistack.start:
-	docker compose -p titan start
 	bash find-start-lms.sh
 	docker compose start
 

--- a/README.rst
+++ b/README.rst
@@ -133,14 +133,13 @@ Local testing with Celery
 With Docker
 ===========
 
-1. First start Titan (if you have it)
-2. Execute `make dev.provision_docker`
+As of the time of this writing, you must have run `make dev.up.ecommerce+lms+redis` in edX's devstack as a prerequisite to this one.
 
-> Note: This will attempt to connect to LMS and create the required superusers, please ensure you have the edX devstack setup first.
+Execute `make dev.provision_docker`
+
+This will attempt to connect to LMS and create the required superusers, please ensure you have the edX devstack setup first.
 
 After you can manage the stack by calling `make dev.up`, `make dev.down` (delete) or `make dev.stop`.
-
-As of the time of this writing, you must have run `make dev.up.ecommerce+lms+redis` in edX's devstack as a prerequisite to this one.
 
 License
 *******

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,14 +29,11 @@ services:
       - "db"
     networks:
       - devstack_default # edX Dev Stack
-      - titan_default    # GetSmarter Titan
       - default          # Just these containers
 
 networks:
   default:
   devstack_default:
-    external: true
-  titan_default:
     external: true
 
 volumes:


### PR DESCRIPTION
**Description:** Removal of Titan requirements to build a composition CC, these modifications will be moved to a private repo, for internal use.

**JIRA:** Link to JIRA ticket

**Dependencies:** NONE

**Merge deadline:** 10 Feb 2023 / 5PM US ET

**Installation instructions:** NONE

**Testing instructions:**

1. Run the provision script `provision-commerce-coordinator.sh` and it shouldnt fail

**Reviewers:**
- [x] @pshiu 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

