### PR TITLE
build: add host.docker.internal to ALLOWED_HOSTS

### DIFF
--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -2,6 +2,11 @@ from commerce_coordinator.settings.base import *
 
 DEBUG = True
 
+ALLOWED_HOSTS += (
+    # Built-in alias to reach the host machine running Docker Desktop from inside a container:
+    'host.docker.internal',
+)
+
 INSTALLED_APPS += (
     'commerce_coordinator.apps.demo_lms.apps.DemoLmsConfig',
 )


### PR DESCRIPTION
## Description

ALLOWED_HOSTS is a Django setting for valid hostnames your app may be aliased as.

host.docker.internal is an internal Docker alias for the host machine running Docker Desktop. (localhost from within a Docker container is the container itself, not the machine running Docker Desktop.)

We are currently using host.docker.internal to reach Coordinator from devstack ecommerce.

Thus, requests arriving to localhost Coordinator may have originally been sent to host.docker.internal:8130 instead of localhost:8130.

This configuration makes Django not reject requests originating from Docker containers with destination to localhost.

## Additional Information
* Jira: [THES-130](https://2u-internal.atlassian.net/browse/THES-130) Coordinator throws error when Titan calls /fulfill
* Related PR: https://github.com/openedx/ecommerce/pull/3953
* See: [Docker docs](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host)

## Testing Information

Tested by seeing successful calls from devstack Ecommerce to local Coordinator.