### PR TITLE
feat: Added providerResponseBody in titan update calls.

### DIFF
--- a/commerce_coordinator/apps/stripe/clients.py
+++ b/commerce_coordinator/apps/stripe/clients.py
@@ -143,6 +143,7 @@ class StripeAPIClient:
 
     def update_payment_intent(
         self,
+        edx_lms_user_id,
         payment_intent_id,
         order_uuid,
         current_payment_number,
@@ -153,6 +154,7 @@ class StripeAPIClient:
         Update a Stripe PaymentIntent.
 
         Args:
+            edx_lms_user_id(int): The edx.org LMS user ID of the user making the payment.
             payment_intent_id (str): The Stripe PaymentIntent id to look up.
             order_uuid (str): The identifier of the order. There should be only
                 one Stripe PaymentIntent for this identifier.
@@ -177,6 +179,7 @@ class StripeAPIClient:
 
         class UpdatePaymentIntentInputSerializer(serializers.CoordinatorSerializer):
             '''Serializer for StripeAPIClient.update_payment_intent.'''
+            edx_lms_user_id = serializers.IntegerField(allow_null=False)
             payment_intent_id = serializers.CharField()
             order_uuid = serializers.UUIDField()
             current_payment_number = serializers.CharField()
@@ -192,6 +195,7 @@ class StripeAPIClient:
                 currency=currency,
                 description=order_uuid,
                 metadata={
+                    'edx_lms_user_id': edx_lms_user_id,
                     'order_number': order_uuid,
                     'payment_number': current_payment_number,
                     'source_system': self.source_system_identifier,

--- a/commerce_coordinator/apps/stripe/pipeline.py
+++ b/commerce_coordinator/apps/stripe/pipeline.py
@@ -74,7 +74,7 @@ class UpdateStripeDraftPayment(PipelineStep):
     Adds titan orders to the order data list.
     """
 
-    def run_filter(self, order_data, payment_data, **kwargs):  # pylint: disable=arguments-differ
+    def run_filter(self, edx_lms_user_id, order_data, payment_data, **kwargs):  # pylint: disable=arguments-differ
         """
         Execute a filter with the signature specified.
         Arguments:
@@ -84,6 +84,7 @@ class UpdateStripeDraftPayment(PipelineStep):
         stripe_api_client = StripeAPIClient()
         try:
             stripe_api_client.update_payment_intent(
+                edx_lms_user_id=edx_lms_user_id,
                 payment_intent_id=payment_data['key_id'],
                 order_uuid=payment_data['order_uuid'],
                 current_payment_number=payment_data['payment_number'],

--- a/commerce_coordinator/apps/stripe/tests/test_clients.py
+++ b/commerce_coordinator/apps/stripe/tests/test_clients.py
@@ -286,6 +286,7 @@ class TestStripeAPIClient(CoordinatorClientTestCase):
         self.assertJSONClientResponse(
             uut=self.client.update_payment_intent,
             input_kwargs={
+                'edx_lms_user_id': 1,
                 'payment_intent_id': TEST_PAYMENT_INTENT_ID,
                 'order_uuid': TEST_ORDER_UUID,
                 'current_payment_number': TEST_PAYMENT_NUMBER,
@@ -296,6 +297,7 @@ class TestStripeAPIClient(CoordinatorClientTestCase):
                 'amount': ['10000'],
                 'currency': ['USD'],
                 'description': [TEST_ORDER_UUID],
+                'metadata[edx_lms_user_id]': ['1'],
                 'metadata[order_number]': [TEST_ORDER_UUID],
                 'metadata[payment_number]': [str(TEST_PAYMENT_NUMBER)],
                 'metadata[source_system]': ['edx/commerce_coordinator?v=1'],
@@ -323,6 +325,7 @@ class TestStripeAPIClient(CoordinatorClientTestCase):
             self.assertJSONClientResponse(
                 uut=self.client.update_payment_intent,
                 input_kwargs={
+                    'edx_lms_user_id': 1,
                     'payment_intent_id': TEST_PAYMENT_INTENT_ID,
                     'order_uuid': TEST_ORDER_UUID,
                     'current_payment_number': TEST_PAYMENT_NUMBER,
@@ -333,6 +336,7 @@ class TestStripeAPIClient(CoordinatorClientTestCase):
                     'amount': ['10000'],
                     'currency': ['USD'],
                     'description': [TEST_ORDER_UUID],
+                    'metadata[edx_lms_user_id]': ['1'],
                     'metadata[order_number]': [TEST_ORDER_UUID],
                     'metadata[payment_number]': [str(TEST_PAYMENT_NUMBER)],
                     'metadata[source_system]': ['edx/commerce_coordinator?v=1'],

--- a/commerce_coordinator/apps/stripe/tests/test_pipeline.py
+++ b/commerce_coordinator/apps/stripe/tests/test_pipeline.py
@@ -96,14 +96,14 @@ class TestUpdateStripeDraftPaymentStep(TestCase):
             'payment_intent_id': 'pi_somecode'
         }
 
-        result: dict = create_update_payment_pipe.run_filter(mock_order_data, mock_payment_data)
+        result: dict = create_update_payment_pipe.run_filter(1, mock_order_data, mock_payment_data)
         mock_update_payment_intent.assert_called()
         self.assertEqual(mock_payment_data['key_id'], result['payment_data']['key_id'])
 
         # Test Error while updating payment intent
         mock_update_payment_intent.side_effect = StripeError
         with self.assertRaises(StripeIntentUpdateAPIError):
-            create_update_payment_pipe.run_filter(mock_order_data, mock_payment_data)
+            create_update_payment_pipe.run_filter(1, mock_order_data, mock_payment_data)
 
 
 class TestConfirmPaymentStep(TestCase):

--- a/commerce_coordinator/apps/stripe/tests/test_views.py
+++ b/commerce_coordinator/apps/stripe/tests/test_views.py
@@ -5,10 +5,12 @@ import logging
 
 import ddt
 import mock
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+from stripe.stripe_object import StripeObject
 from testfixtures import LogCapture
 
 from commerce_coordinator.apps.core.constants import PaymentState
@@ -80,15 +82,19 @@ class WebhooksViewTests(APITestCase):
     @ddt.data(
         name_test(
             "test payment success event",
-            (StripeEventType.PAYMENT_SUCCESS.value, PaymentState.COMPLETED.value, status.HTTP_200_OK)
+            (StripeEventType.PAYMENT_SUCCESS.value, None, PaymentState.COMPLETED.value, status.HTTP_200_OK)
+        ),
+        name_test(
+            "test payment success event with unknown source",
+            (StripeEventType.PAYMENT_SUCCESS.value, 'unknown-source', None, status.HTTP_200_OK)
         ),
         name_test(
             "test payment failure",
-            (StripeEventType.PAYMENT_FAILED.value, PaymentState.FAILED.value, status.HTTP_200_OK)
+            (StripeEventType.PAYMENT_FAILED.value, None, PaymentState.FAILED.value, status.HTTP_200_OK)
         ),
         name_test(
             "test event not handled by the webhook",
-            ('account_updated', None, status.HTTP_422_UNPROCESSABLE_ENTITY),
+            ('account_updated', None, None, status.HTTP_422_UNPROCESSABLE_ENTITY),
         )
     )
     @ddt.unpack
@@ -97,6 +103,7 @@ class WebhooksViewTests(APITestCase):
     def test_handled_webhook_event(
         self,
         event_type,
+        source_system,
         expected_payment_state,
         expected_status,
         mock_construct_event,
@@ -108,13 +115,25 @@ class WebhooksViewTests(APITestCase):
         amount = 10000
         payment_intent_id = 'pi_789dummy'
         payment_number = 123456
+        order_uuid = 123456
+        edx_lms_user_id = 123456
+        default_source_system = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['source_system_identifier']
+        source_system = source_system or default_source_system
         self.mock_stripe_event.type = event_type
-        self.mock_stripe_event.data.object.amount = amount
-        self.mock_stripe_event.data.object.metadata.payment_number = payment_number
         self.mock_stripe_event.data.object.id = payment_intent_id
+        self.mock_stripe_event.data.object.amount = amount
+        metadata = {
+            'payment_number': payment_number,
+            'order_uuid': order_uuid,
+            'edx_lms_user_id': edx_lms_user_id,
+            'source_system': source_system
+        }
+        body = {'data': {'object': {'metadata': metadata}}}
+        self.mock_stripe_event.data.object.metadata = StripeObject()
+        self.mock_stripe_event.data.object.metadata.update(metadata)
         mock_construct_event.return_value = self.mock_stripe_event
         with LogCapture(log_name) as log_capture:
-            response = self.client.post(self.url, **self.mock_header)
+            response = self.client.post(self.url, data=body, format='json', **self.mock_header)
             self.assertEqual(response.status_code, expected_status)
             if expected_status == status.HTTP_200_OK:
                 log_capture.check_present(
@@ -122,11 +141,12 @@ class WebhooksViewTests(APITestCase):
                         log_name,
                         'INFO',
                         f'[Stripe webhooks] event {event_type} with amount {amount} and '
-                        f'payment intent ID [{payment_intent_id}].',
+                        f'payment intent ID [{payment_intent_id}], source: [{source_system}].',
                     )
                 )
-                mock_payment_processed_save_task.assert_called_with(
-                    payment_number, expected_payment_state, payment_intent_id
-                )
+                if expected_payment_state:
+                    mock_payment_processed_save_task.assert_called_with(
+                        edx_lms_user_id, order_uuid, payment_number, expected_payment_state, payment_intent_id, body
+                    )
             else:
                 mock_payment_processed_save_task.assert_not_called()

--- a/commerce_coordinator/apps/titan/clients.py
+++ b/commerce_coordinator/apps/titan/clients.py
@@ -208,25 +208,36 @@ class TitanAPIClient(Client):
 
         return response['data']['attributes']
 
-    def update_payment(self, payment_number, payment_state, response_code):
+    def update_payment(
+        self, edx_lms_user_id, order_uuid, payment_number, payment_state, reference_number, provider_response_body=None
+    ):
         """
         Request Titan to update payment.
 
         Args:
+            edx_lms_user_id: The edx.org LMS user ID of the user making the payment.
+            order_uuid: Order UUID related to this order.
             payment_number: The Payment identifier in Spree.
             payment_state: State to advance the payment to.
-            response_code: Payment attempt response code provided by stripe.
+            reference_number: Payment client intent key.
+            provider_response_body: Optional. The saved response from a request to the payment provider.
         """
+        data_attributes = {
+            'edxLmsUserId': edx_lms_user_id,
+            'orderUuid': order_uuid,
+            'paymentNumber': payment_number,
+            'paymentState': payment_state,
+            'referenceNumber': reference_number,
+        }
+        if provider_response_body is not None:
+            data_attributes['providerResponseBody'] = provider_response_body
+
         response = self._request(
             request_method='PATCH',
             resource_path='payments',
             json={
                 'data': {
-                    'attributes': {
-                        'paymentNumber': payment_number,
-                        'paymentState': payment_state,
-                        'responseCode': response_code,
-                    }
+                    'attributes': data_attributes
                 }
             },
         )

--- a/commerce_coordinator/apps/titan/pipeline.py
+++ b/commerce_coordinator/apps/titan/pipeline.py
@@ -234,17 +234,23 @@ class UpdateTitanPayment(PipelineStep):
 
     def run_filter(
         self,
+        edx_lms_user_id,
+        order_uuid,
         payment_number,
         payment_state,
-        response_code
+        payment_intent_id,
+        **kwargs
     ):  # pylint: disable=arguments-differ
 
         api_client = TitanAPIClient()
         try:
             response = api_client.update_payment(
+                edx_lms_user_id=edx_lms_user_id,
+                order_uuid=order_uuid,
                 payment_number=payment_number,
                 payment_state=payment_state,
-                response_code=response_code)
+                reference_number=payment_intent_id
+            )
 
         except HTTPError as exc:
             logger.exception(

--- a/commerce_coordinator/apps/titan/signals.py
+++ b/commerce_coordinator/apps/titan/signals.py
@@ -51,8 +51,11 @@ def payment_processed_save(**kwargs):
     Update an payment.
     """
     async_result = payment_processed_save_task.delay(
+        kwargs['edx_lms_user_id'],
+        kwargs['order_uuid'],
         kwargs['payment_number'],
         kwargs['payment_state'],
-        kwargs['response_code'],
+        kwargs['reference_number'],
+        kwargs['provider_response_body'],
     )
     return async_result.id

--- a/commerce_coordinator/apps/titan/tests/test_pipeline.py
+++ b/commerce_coordinator/apps/titan/tests/test_pipeline.py
@@ -371,7 +371,9 @@ class TestUpdateTitanPaymentStep(TestCase):
         self.update_payment_data = {
             'payment_number': '1234',
             'payment_state': PaymentState.PROCESSING.value,
-            'response_code': 'a_stripe_response_code',
+            'edx_lms_user_id': 1,
+            'order_uuid': ORDER_UUID,
+            'payment_intent_id': 'fake-intent',
         }
         self.update_payment_response = {
             'number': '1234',

--- a/commerce_coordinator/apps/titan/tests/test_tasks.py
+++ b/commerce_coordinator/apps/titan/tests/test_tasks.py
@@ -62,9 +62,12 @@ class TestPaymentTasks(TestCase):
         }
         payment_number = '12345'
         payment_update_params = {
+            'edx_lms_user_id': 1,
+            'order_uuid': ORDER_UUID,
             'payment_number': payment_number,
             'payment_state': payment_state,
-            'response_code': 'g7h52545gavgatTh'
+            'reference_number': 'g7h52545gavgatTh',
+            'provider_response_body': {'key': 'value'}
          }
         payment_processed_save_task.apply(
             kwargs=payment_update_params
@@ -92,11 +95,14 @@ class TestPaymentTasks(TestCase):
         """
         TieredCache.dangerous_clear_all_tiers()
         payment_number = '12345'
-        response_code = 'g7h52545gavgatTh'
+        reference_number = 'g7h52545gavgatTh'
         payment_update_params = {
+            'edx_lms_user_id': 1,
+            'order_uuid': ORDER_UUID,
             'payment_number': payment_number,
             'payment_state': payment_state,
-            'response_code': response_code
+            'reference_number': reference_number,
+            'provider_response_body': {'key': 'value'}
         }
         with LogCapture(log_name) as log_capture:
             payment_processed_save_task.apply(
@@ -107,7 +113,7 @@ class TestPaymentTasks(TestCase):
                     log_name,
                     'ERROR',
                     f'Titan payment_processed_save_task Failed with payment_number: {payment_number}, '
-                    f'payment_state: {payment_state},and response_code: {response_code}. Exception: '
+                    f'payment_state: {payment_state},and reference_number: {reference_number}. Exception: '
                 )
             )
         mock_update_payment.assert_called_with(

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -144,6 +144,7 @@ PAYMENT_PROCESSOR_CONFIG = {
             'proxy': None,
             'publishable_key': 'SET-ME-PLEASE',
             'secret_key': 'SET-ME-PLEASE',
+            'source_system_identifier': 'edx/commerce_coordinator?v=1',
             'webhook_endpoint_secret': 'SET-ME-PLEASE',
         },
     },

--- a/commerce_coordinator/settings/test.py
+++ b/commerce_coordinator/settings/test.py
@@ -2,6 +2,23 @@ import os
 
 from commerce_coordinator.settings.base import *
 
+PAYMENT_PROCESSOR_CONFIG = {
+    'edx': {
+        'stripe': {
+            'api_version': '2022-08-01; server_side_confirmation_beta=v1',
+            'enable_telemetry': None,
+            'log_level': 'info',
+            'max_network_retries': 0,
+            'proxy': None,
+            'publishable_key': 'SET-ME-PLEASE',
+            'secret_key': 'SET-ME-PLEASE',
+            'source_system_identifier': 'edx/commerce_coordinator?v=1',
+            'webhook_endpoint_secret': 'SET-ME-PLEASE',
+        },
+    },
+}
+# END PAYMENT PROCESSING
+
 # IN-MEMORY TEST DATABASE
 DATABASES = {
     'default': {


### PR DESCRIPTION
**Description:**

* Added `providerResponseBody` in titan payment update calls.
* Also Added `edxLmsUserId` and `orderUuid` in titan payment update calls.
* rename `responseCode` to `referenceNumber`.
* Updated stripe update call to save `edx_lms_user_id` in metadata.
* Added check for source_system in Stripe Webhook.

**JIRA:** [THES-195](https://2u-internal.atlassian.net/browse/THES-195)
