### PR TITLE
feat: add create_payment call after a payment failure

### DIFF
--- a/commerce_coordinator/apps/titan/exceptions.py
+++ b/commerce_coordinator/apps/titan/exceptions.py
@@ -21,6 +21,12 @@ class ProcessingAlreadyRequested(APIException):
     default_code = 'already_processing'
 
 
+class StaleOrder(APIException):
+    status_code = 409
+    default_detail = 'The supplied orderUuid does not match the latest active orderUuid for the supplied edxLmsUserId'
+    default_code = 'stale_order'
+
+
 class AlreadyPaid(APIException):
     status_code = 409
     default_detail = 'The payment was already paid.'

--- a/commerce_coordinator/apps/titan/tasks.py
+++ b/commerce_coordinator/apps/titan/tasks.py
@@ -12,9 +12,8 @@ from commerce_coordinator.apps.core.cache import (
     get_paid_payment_state_cache_key,
     get_processing_payment_state_cache_key
 )
-from commerce_coordinator.apps.core.constants import PaymentState
-
-from .clients import TitanAPIClient
+from commerce_coordinator.apps.core.constants import PaymentMethod, PaymentState
+from commerce_coordinator.apps.titan.clients import TitanAPIClient
 
 logger = get_task_logger(__name__)
 
@@ -102,8 +101,22 @@ def payment_processed_save_task(
             payment_state_paid_cache_key = get_paid_payment_state_cache_key(payment_number)
             TieredCache.set_all_tiers(payment_state_paid_cache_key, payment, settings.DEFAULT_TIMEOUT)
         elif payment_state == PaymentState.FAILED.value:
+            if 'metadata' in provider_response_body:
+                if 'payment_number' in provider_response_body['metadata']:
+                    provider_response_body['metadata']['payment_number'] = ''
+                if 'order_number' in provider_response_body['metadata']:
+                    order_uuid = provider_response_body['metadata']['order_number']
+            titan_api_client.create_payment(
+                order_uuid=order_uuid,
+                reference_number=reference_number,
+                payment_method_name=PaymentMethod.STRIPE.value,
+                provider_response_body=provider_response_body,
+                edx_lms_user_id=edx_lms_user_id
+            )
+            #  TODO: update payment in stripe with new payment number
             payment_state_processing_cache_key = get_processing_payment_state_cache_key(payment_number)
             TieredCache.set_all_tiers(payment_state_processing_cache_key, payment, settings.DEFAULT_TIMEOUT)
+
     except HTTPError as ex:
         logger.exception('Titan payment_processed_save_task Failed '
                          f'with payment_number: {payment_number}, payment_state: {payment_state},'

--- a/commerce_coordinator/apps/titan/tests/test_tasks.py
+++ b/commerce_coordinator/apps/titan/tests/test_tasks.py
@@ -9,8 +9,8 @@ from testfixtures import LogCapture
 from commerce_coordinator.apps.titan.tasks import order_created_save_task, payment_processed_save_task
 
 from ...core.cache import get_paid_payment_state_cache_key, get_processing_payment_state_cache_key
-from ...core.constants import PaymentState
-from .test_clients import ORDER_CREATE_DATA, ORDER_UUID, TitanClientMock
+from ...core.constants import PaymentMethod, PaymentState
+from .test_clients import ORDER_CREATE_DATA, ORDER_UUID, TitanClientMock, titan_active_order_response
 
 log_name = 'commerce_coordinator.apps.titan.tasks'
 
@@ -49,7 +49,8 @@ class TestPaymentTasks(TestCase):
 
     @ddt.data(PaymentState.COMPLETED.value, PaymentState.FAILED.value)
     @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.update_payment')
-    def test_payment_processed_save_task(self, payment_state, mock_update_payment):
+    @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.create_payment')
+    def test_payment_processed_save_task(self, payment_state, mock_create_payment, mock_update_payment):
         """ Ensure that the `payment_processed_save_task` invokes create update_payment as expected.
 
         Args:
@@ -67,8 +68,25 @@ class TestPaymentTasks(TestCase):
             'payment_number': payment_number,
             'payment_state': payment_state,
             'reference_number': 'g7h52545gavgatTh',
-            'provider_response_body': {'key': 'value'}
+            'provider_response_body': {'key': 'value',
+                                       'metadata': {
+                                           'order_number': ORDER_UUID,
+                                           'payment_number': payment_number,
+                                       },
+                                       }
          }
+        payment_create_params = {
+            'edx_lms_user_id': 1,
+            'order_uuid': ORDER_UUID,
+            'payment_method_name': PaymentMethod.STRIPE.value,
+            'reference_number': 'g7h52545gavgatTh',
+            'provider_response_body': {'key': 'value',
+                                       'metadata': {
+                                           'order_number': ORDER_UUID,
+                                           'payment_number': '',
+                                       },
+                                       }
+        }
         payment_processed_save_task.apply(
             kwargs=payment_update_params
         ).get()
@@ -81,16 +99,22 @@ class TestPaymentTasks(TestCase):
         if payment_state == PaymentState.COMPLETED.value:
             payment_state_cache_key = get_paid_payment_state_cache_key(payment_number)
         if payment_state == PaymentState.FAILED.value:
+            mock_create_payment.return_value = titan_active_order_response['payments'][0]
+            mock_create_payment.assert_called_with(
+                **payment_create_params
+            )
             payment_state_cache_key = get_processing_payment_state_cache_key(payment_number)
         cached_response = TieredCache.get_cached_response(payment_state_cache_key)
         self.assertTrue(cached_response.is_found)
 
     @ddt.data(PaymentState.COMPLETED.value, PaymentState.FAILED.value)
     @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.update_payment', side_effect=HTTPError)
-    def test_payment_processed_save_task_failure(self, payment_state, mock_update_payment):
+    @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.create_payment', side_effect=HTTPError)
+    def test_payment_processed_save_task_failure(self, payment_state, mock_create_payment, mock_update_payment):
         """ Ensure that the `payment_processed_save_task` logs error in case of exception.
 
         Args:
+            mock_create_payment (TitanClientMock): Titan Client Mock for its mock_create_payment command.
             mock_update_payment (TitanClientMock): Titan Client Mock for its mock_update_payment command.
         """
         TieredCache.dangerous_clear_all_tiers()
@@ -124,5 +148,65 @@ class TestPaymentTasks(TestCase):
             payment_state_cache_key = get_paid_payment_state_cache_key(payment_number)
         if payment_state == PaymentState.FAILED.value:
             payment_state_cache_key = get_processing_payment_state_cache_key(payment_number)
+            mock_create_payment.return_value = titan_active_order_response['payments'][0]
         cached_response = TieredCache.get_cached_response(payment_state_cache_key)
         self.assertFalse(cached_response.is_found)
+
+    @ddt.data(PaymentState.FAILED.value)
+    @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.update_payment')
+    @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.create_payment')
+    def test_payment_processed_save_task_missing_metadata(
+        self,
+        payment_state,
+        mock_create_payment,
+        mock_update_payment
+    ):
+        """
+        Args:
+            mock_create_payment (TitanClientMock): Titan Client Mock for its mock_create_payment command.
+            mock_update_payment (TitanClientMock): Titan Client Mock for its mock_update_payment command.
+        """
+        TieredCache.dangerous_clear_all_tiers()
+        mock_update_payment.return_value = {
+            'uuid': ORDER_UUID,
+            'state': payment_state
+        }
+        payment_number = '12345'
+        payment_update_params = {
+            'edx_lms_user_id': 1,
+            'order_uuid': ORDER_UUID,
+            'payment_number': payment_number,
+            'payment_state': payment_state,
+            'reference_number': 'g7h52545gavgatTh',
+            'provider_response_body': {'key': 'value'}
+         }
+        payment_create_params = {
+            'edx_lms_user_id': 1,
+            'order_uuid': ORDER_UUID,
+            'payment_method_name': PaymentMethod.STRIPE.value,
+            'reference_number': 'g7h52545gavgatTh',
+            'provider_response_body': {'key': 'value'}
+        }
+        payment_processed_save_task.apply(
+            kwargs=payment_update_params
+        ).get()
+
+        mock_update_payment.assert_called_with(
+            **payment_update_params
+        )
+
+        if payment_state == PaymentState.FAILED.value:
+            mock_create_payment.return_value = titan_active_order_response['payments'][0]
+            mock_create_payment.assert_called_with(
+                **payment_create_params
+            )
+        payment_update_params['provider_response_body']['metadata'] = {}
+        payment_create_params['provider_response_body']['metadata'] = {}
+
+        payment_processed_save_task.apply(
+            kwargs=payment_update_params
+        ).get()
+
+        mock_create_payment.assert_called_with(
+                **payment_create_params
+            )


### PR DESCRIPTION
[THES-231](https://2u-internal.atlassian.net/browse/THES-231)

Added create payment call to payment_process_save_task and updated tests

Note: Added as a client call but if theres a way to call a pipeline step from within a signal task it might be better to swap to calling the pipeline step instead