### PR TITLE
feat: add stripe.pipeline.GetStripeDraftPayment

### DIFF
--- a/commerce_coordinator/apps/core/constants.py
+++ b/commerce_coordinator/apps/core/constants.py
@@ -8,6 +8,28 @@ class Status:
     UNAVAILABLE = "UNAVAILABLE"
 
 
+class OrderState(Enum):
+    """
+    Enum for order states.
+    """
+    CART = 'cart'
+    ADDRESS = 'address'
+    PAYMENT = 'payment'
+    COMPLETE = 'complete'
+    CANCELED = 'canceled'
+
+
+class OrderPaymentState(Enum):
+    """
+    Enum for the state of payment of an order.
+    """
+    BALANCE_DUE = 'balance_due'
+    FAILED = 'failed'
+    PAID = 'paid'
+    VOID = 'void'
+    CREDIT_OWED = 'credit_owed'
+
+
 class PaymentState(Enum):
     """
     Enum for Payment states, Controlled by Titan's System.

--- a/commerce_coordinator/apps/core/constants.py
+++ b/commerce_coordinator/apps/core/constants.py
@@ -38,7 +38,6 @@ class PaymentState(Enum):
     COMPLETED = 'completed'
     FAILED = 'failed'
     PENDING = 'pending'
-    PROCESSING = 'processing'
 
 
 class PaymentMethod(Enum):

--- a/commerce_coordinator/apps/frontend_app_payment/filters.py
+++ b/commerce_coordinator/apps/frontend_app_payment/filters.py
@@ -52,7 +52,7 @@ class PaymentRequested(OpenEdxPublicFilter):
         payment_state = payment["state"]
         if payment_state == PaymentState.COMPLETED.value:
             TieredCache.set_all_tiers(payment_state_paid_cache_key, payment, settings.DEFAULT_TIMEOUT)
-        elif payment_state in [PaymentState.PROCESSING.value, PaymentState.FAILED.value]:
+        elif payment_state in [PaymentState.PENDING.value, PaymentState.FAILED.value]:
             TieredCache.set_all_tiers(payment_state_processing_cache_key, payment, settings.DEFAULT_TIMEOUT)
 
         return payment

--- a/commerce_coordinator/apps/frontend_app_payment/tests/test_views.py
+++ b/commerce_coordinator/apps/frontend_app_payment/tests/test_views.py
@@ -285,10 +285,12 @@ class DraftPaymentCreateViewTests(APITestCase):
     @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.get_active_order')
     @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.create_payment')
     @patch('commerce_coordinator.apps.stripe.clients.StripeAPIClient.create_payment_intent')
+    @patch('commerce_coordinator.apps.stripe.clients.StripeAPIClient.retrieve_payment_intent')
     @patch('commerce_coordinator.apps.stripe.clients.StripeAPIClient.update_payment_intent')
     def test_create_payment(
         self,
         mock_update_payment_intent,
+        mock_retrieve_payment_intent,
         mock_create_payment_intent,
         mock_create_payment,
         mock_get_active_order
@@ -301,6 +303,10 @@ class DraftPaymentCreateViewTests(APITestCase):
         mock_get_active_order_response = copy.deepcopy(titan_active_order_response)
         mock_get_active_order.return_value = mock_get_active_order_response
         mock_create_payment_intent.return_value = {
+            'id': intent_id,
+            'client_secret': intent_id
+        }
+        mock_retrieve_payment_intent.return_value = {
             'id': intent_id,
             'client_secret': intent_id
         }

--- a/commerce_coordinator/apps/frontend_app_payment/tests/test_views.py
+++ b/commerce_coordinator/apps/frontend_app_payment/tests/test_views.py
@@ -109,7 +109,7 @@ class GetPaymentViewTests(APITestCase):
 
         response_json = response.json()
         if expected_status == status.HTTP_200_OK:
-            self.assertEqual(response_json['state'], PaymentState.PROCESSING.value)
+            self.assertEqual(response_json['state'], PaymentState.PENDING.value)
             self.assertTrue(mock_get_payment.called)
             kwargs = mock_get_payment.call_args.kwargs
             self.assertEqual(kwargs['edx_lms_user_id'], self.test_lms_user_id)
@@ -126,7 +126,7 @@ class GetPaymentViewTests(APITestCase):
         self.assertEqual(response_json['state'], expected_state)
 
     @ddt.data(
-        PaymentState.PROCESSING.value, PaymentState.COMPLETED.value, PaymentState.FAILED.value
+        PaymentState.PENDING.value, PaymentState.COMPLETED.value, PaymentState.FAILED.value
     )
     @patch('commerce_coordinator.apps.titan.pipeline.GetTitanPayment.run_filter')
     def test_get_payment_cache(self, payment_state, mock_pipeline):
@@ -179,7 +179,7 @@ class GetPaymentViewTests(APITestCase):
             'payment_number': payment_number,
             'order_uuid': ORDER_UUID,
             'key_id': 'test-code',
-            'state': PaymentState.PROCESSING.value
+            'state': PaymentState.PENDING.value
         }
         query_params = {
             'order_uuid': '123e4567-e89b-12d3-a456-426614174000',
@@ -192,7 +192,7 @@ class GetPaymentViewTests(APITestCase):
             payment_number, CachePaymentStates.PROCESSING.value
         )
         TieredCache.set_all_tiers(payment_state_processing_cache_key, payment, settings.DEFAULT_TIMEOUT)
-        self._assert_get_payment_api_response(query_params, PaymentState.PROCESSING.value)
+        self._assert_get_payment_api_response(query_params, PaymentState.PENDING.value)
 
         # Let's assume, Something happened, and we lost cache. We should get cache restored.
         mock_pipeline.reset_mock()
@@ -200,7 +200,7 @@ class GetPaymentViewTests(APITestCase):
         cached_response = TieredCache.get_cached_response(payment_state_processing_cache_key)
         self.assertFalse(cached_response.is_found)
         mock_pipeline.return_value = {'payment_data': payment}
-        self._assert_get_payment_api_response(query_params, PaymentState.PROCESSING.value)
+        self._assert_get_payment_api_response(query_params, PaymentState.PENDING.value)
         self.assertTrue(mock_pipeline.called)
         cached_response = TieredCache.get_cached_response(payment_state_processing_cache_key)
         self.assertTrue(cached_response.is_found)

--- a/commerce_coordinator/apps/stripe/exceptions.py
+++ b/commerce_coordinator/apps/stripe/exceptions.py
@@ -37,3 +37,9 @@ class StripeIntentConfirmAPIError(APIException):
     status_code = 502
     default_detail = 'Error while confirming payment intent on payment gateway.'
     default_code = 'stripe_intent_confirm_error'
+
+
+class StripeIntentRetrieveAPIError(APIException):
+    status_code = 502
+    default_detail = 'Error while retrieving payment intent on payment gateway.'
+    default_code = 'stripe_intent_retrieve_error'

--- a/commerce_coordinator/apps/stripe/pipeline.py
+++ b/commerce_coordinator/apps/stripe/pipeline.py
@@ -66,7 +66,6 @@ class CreateOrGetStripeDraftPayment(PipelineStep):
         )
         return {
             'payment_data': payment,
-            'order_data': order_data,
             'payment_intent_data': payment_intent,
         }
 
@@ -130,8 +129,6 @@ class UpdateStripeDraftPayment(PipelineStep):
             raise StripeIntentUpdateAPIError from ex
 
         return {
-            'payment_data': payment_data,
-            'order_data': order_data,
             'payment_intent_data': payment_intent,
         }
 
@@ -198,6 +195,5 @@ class ConfirmPayment(PipelineStep):
             raise StripeIntentConfirmAPIError from ex
 
         return {
-            'payment_data': payment_data,
             'payment_intent_data': payment_intent,
         }

--- a/commerce_coordinator/apps/stripe/pipeline.py
+++ b/commerce_coordinator/apps/stripe/pipeline.py
@@ -67,6 +67,7 @@ class CreateOrGetStripeDraftPayment(PipelineStep):
         return {
             'payment_data': payment,
             'order_data': order_data,
+            'payment_intent_data': payment_intent,
         }
 
 
@@ -117,7 +118,7 @@ class UpdateStripeDraftPayment(PipelineStep):
 
         stripe_api_client = StripeAPIClient()
         try:
-            stripe_api_client.update_payment_intent(
+            payment_intent = stripe_api_client.update_payment_intent(
                 edx_lms_user_id=edx_lms_user_id,
                 payment_intent_id=payment_data['key_id'],
                 order_uuid=payment_data['order_uuid'],
@@ -131,6 +132,7 @@ class UpdateStripeDraftPayment(PipelineStep):
         return {
             'payment_data': payment_data,
             'order_data': order_data,
+            'payment_intent_data': payment_intent,
         }
 
 
@@ -189,7 +191,7 @@ class ConfirmPayment(PipelineStep):
 
         stripe_api_client = StripeAPIClient()
         try:
-            stripe_api_client.confirm_payment_intent(
+            payment_intent = stripe_api_client.confirm_payment_intent(
                 payment_intent_id=payment_data['key_id'],
             )
         except StripeError as ex:
@@ -197,4 +199,5 @@ class ConfirmPayment(PipelineStep):
 
         return {
             'payment_data': payment_data,
+            'payment_intent_data': payment_intent,
         }

--- a/commerce_coordinator/apps/stripe/pipeline.py
+++ b/commerce_coordinator/apps/stripe/pipeline.py
@@ -27,13 +27,13 @@ class CreateOrGetStripeDraftPayment(PipelineStep):
     Adds titan orders to the order data list.
     """
 
-    def run_filter(self, order_data, recent_payment, **kwargs):  # pylint: disable=arguments-differ
+    def run_filter(self, order_data, recent_payment, edx_lms_user_id, **kwargs):  # pylint: disable=arguments-differ
         """
         Execute a filter with the signature specified.
         Arguments:
             recent_payment: most recent payment from order (from earlier pipeline step).
             order_data: any preliminary orders (from earlier pipeline step) we want to append to.
-            kwargs: arguments passed through from the filter.
+            edx_lms_user_id: the user id requesting the draft payment.
         """
 
         if recent_payment and recent_payment['state'] != PaymentState.FAILED.value:
@@ -62,7 +62,7 @@ class CreateOrGetStripeDraftPayment(PipelineStep):
             client_secret=payment_intent['client_secret'],
             payment_method_name=PaymentMethod.STRIPE.value,
             provider_response_body=payment_intent,
-            edx_lms_user_id=kwargs['edx_lms_user_id']
+            edx_lms_user_id=edx_lms_user_id
         )
         return {
             'payment_data': payment,

--- a/commerce_coordinator/apps/stripe/pipeline.py
+++ b/commerce_coordinator/apps/stripe/pipeline.py
@@ -24,7 +24,11 @@ logger = logging.getLogger(__name__)
 
 class CreateOrGetStripeDraftPayment(PipelineStep):
     """
-    Adds titan orders to the order data list.
+    Create or retrieve previous creation attempts of a Stripe PaymentIntent.
+
+    Use the order number as an idempotency key so Stripe will replay responses
+    for creation attempts of a PaymentIntent for the same order number in the
+    last 24 hours.
     """
 
     def run_filter(self, order_data, recent_payment, edx_lms_user_id, **kwargs):  # pylint: disable=arguments-differ

--- a/commerce_coordinator/apps/titan/pipeline.py
+++ b/commerce_coordinator/apps/titan/pipeline.py
@@ -147,7 +147,7 @@ class CreateDraftPayment(PipelineStep):
             provider_response_body(str): The response JSON dump from a request to the payment provider.
             payment_intent_id(str): A Stripe Payment Intent ID (used to update payment intents)
             client_secret(str): A Stripe client secret string used by the UI to load the Stripe payment form.
-            edx_lms_user_id(str): edC LMS User ID
+            edx_lms_user_id(str): edX LMS User ID
         """
 
         api_client = TitanAPIClient()

--- a/commerce_coordinator/apps/titan/pipeline.py
+++ b/commerce_coordinator/apps/titan/pipeline.py
@@ -132,11 +132,10 @@ class ValidateOrderReadyForDraftPayment(PipelineStep):
             return None  # Order does not need draft payment. Halt pipeline.
         elif recent_payment['state'] == PaymentState.FAILED.value:
             return {}  # Continue. Will generate a new draft payment.
-        else:
-            # Inform pipeline that a draft payment already exists:
-            return {
-                'payment_data': recent_payment
-            }
+        # Inform pipeline that a draft payment already exists:
+        return {
+            'payment_data': recent_payment
+        }
 
 
 class ValidatePaymentReadyForProcessing(PipelineStep):

--- a/commerce_coordinator/apps/titan/tests/test_clients.py
+++ b/commerce_coordinator/apps/titan/tests/test_clients.py
@@ -5,7 +5,7 @@ import ddt
 from django.test import override_settings
 from requests.exceptions import HTTPError
 
-from commerce_coordinator.apps.core.constants import PaymentMethod, PaymentState
+from commerce_coordinator.apps.core.constants import OrderPaymentState, PaymentMethod, PaymentState
 from commerce_coordinator.apps.core.tests.utils import CoordinatorClientTestCase
 from commerce_coordinator.apps.titan.clients import TitanAPIClient, urljoin_directory
 
@@ -60,7 +60,7 @@ titan_active_order_response = {
         'uuid': ORDER_UUID,
         'promoTotal': '0.0',
         'itemCount': 1,
-        'paymentState': None,
+        'paymentState': OrderPaymentState.BALANCE_DUE.value,
         'paymentTotal': '0.0',
         'user': {
             'firstName': 'test',

--- a/commerce_coordinator/apps/titan/tests/test_clients.py
+++ b/commerce_coordinator/apps/titan/tests/test_clients.py
@@ -40,7 +40,7 @@ class TitanPaymentClientMock(MagicMock):
     """A mock TitanClient."""
     return_value = {
         'orderUuid': ORDER_UUID,
-        'state': PaymentState.PROCESSING.value,
+        'state': PaymentState.PENDING.value,
         'referenceNumber': 'test-code',
         'number': 'test-number'
     }

--- a/commerce_coordinator/apps/titan/tests/test_pipeline.py
+++ b/commerce_coordinator/apps/titan/tests/test_pipeline.py
@@ -198,9 +198,6 @@ class TestValidatePaymentReadyForProcessingStep(TestCase):
         (
             PaymentState.FAILED.value, None, None
         ),
-        (
-            PaymentState.PROCESSING.value, None, None
-        ),
     )
     @ddt.unpack
     @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.get_payment')
@@ -370,7 +367,7 @@ class TestUpdateTitanPaymentStep(TestCase):
     def setUp(self) -> None:
         self.update_payment_data = {
             'payment_number': '1234',
-            'payment_state': PaymentState.PROCESSING.value,
+            'payment_state': PaymentState.PENDING.value,
             'edx_lms_user_id': 1,
             'order_uuid': ORDER_UUID,
             'payment_intent_id': 'fake-intent',
@@ -379,7 +376,7 @@ class TestUpdateTitanPaymentStep(TestCase):
             'number': '1234',
             'orderUuid': ORDER_UUID,
             'referenceNumber': 'a_stripe_response_code',
-            'state': PaymentState.PROCESSING.value,
+            'state': PaymentState.PENDING.value,
         }
 
     @patch('commerce_coordinator.apps.titan.clients.TitanAPIClient.update_payment')

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -379,6 +379,7 @@ OPEN_EDX_FILTERS_CONFIG = {
         "fail_silently": False,  # TODO: Coordinator filters should NEVER be allowed to fail silently
         "pipeline": [
             'commerce_coordinator.apps.titan.pipeline.GetTitanActiveOrder',
+            'commerce_coordinator.apps.stripe.pipeline.GetStripeDraftPayment',
             'commerce_coordinator.apps.stripe.pipeline.CreateOrGetStripeDraftPayment',
             'commerce_coordinator.apps.stripe.pipeline.UpdateStripeDraftPayment',
 

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -379,6 +379,7 @@ OPEN_EDX_FILTERS_CONFIG = {
         "fail_silently": False,  # TODO: Coordinator filters should NEVER be allowed to fail silently
         "pipeline": [
             'commerce_coordinator.apps.titan.pipeline.GetTitanActiveOrder',
+            'commerce_coordinator.apps.titan.pipeline.ValidateOrderReadyForDraftPayment',
             'commerce_coordinator.apps.stripe.pipeline.GetStripeDraftPayment',
             'commerce_coordinator.apps.stripe.pipeline.CreateOrGetStripeDraftPayment',
             'commerce_coordinator.apps.stripe.pipeline.UpdateStripeDraftPayment',


### PR DESCRIPTION
## Description

- In stripe Coordinator app:
  - Implement clients.StripeAPIClient.retrieve_payment_intent
    - Create unit tests for client 
  - Implement pipeline.GetStripeDraftPayment
    - Create unit tests for pipeline step
- Connect frontend-app-payment.filters.DraftPaymentRequested to pipeline.GetStripeDraftPayment

```mermaid
sequenceDiagram
    participant P as Payment MFE
    participant C as Coordinator
    participant T as Titan
    participant S as Stripe

    P->>+C: Create or Get Draft Payment
    C-->>-P: (response)

    C->>+T: Get Active Order
    T-->>-C: (response)

    alt Active, unpaid payment found from Titan
        rect rgb(255, 245, 173, .25)
            note over T: New:
            C->>+S: Get Draft Payment
            S-->>-C: (response)
        end
        C-->>P: (response with payment_number and order_uuid)
    end
```

## Additional Information

* Jira: [THES-215](https://2u-internal.atlassian.net/browse/THES-215)