### PR TITLE
refactor: add PipelineCommand Enum & convert comments to debug messages

### DIFF
--- a/commerce_coordinator/apps/core/constants.py
+++ b/commerce_coordinator/apps/core/constants.py
@@ -44,26 +44,45 @@ class PaymentMethod(Enum):
     STRIPE = 'edX Stripe'
 
 
+class PipelineCommand(Enum):
+    """
+    Special return values for openedx-filters PipelineStep.
+
+    https://github.com/openedx/openedx-filters/blob/2d6b87b5cc4263dd3577fb27c354ec36797979c9/openedx_filters/filters.py#L70-L75
+    """
+
+    CONTINUE = {}
+    """Pass unaltered inputs to next pipeline step."""
+
+    HALT = None
+    """Abort any remaining pipeline steps for filter."""
+
+
 class QueryParamPrefixes(Enum):
     """Query Param Prefixes"""
+
     WAFFLE_FLAG = 'dwft_'
     """Django Waffle Flag"""
+
     GOOGLE_ANALYTICS = 'utm_'
     """Google Analytics (Urchin Tracking Module)"""
 
 
 class WaffleFlagNames(Enum):
     """List of Waffle Flags"""
+
     COORDINATOR_ENABLED = 'transition_to_coordinator.order_create'
     """MFE Commerce Coordinator Flow Flag"""
 
 
 class MediaTypes(Enum):
     """IANA Media Types (used to be called Mime-Types)"""
+
     JSON = 'application/json'
 
 
 class HttpHeadersNames(Enum):
     """Standard HTTP Header Names"""
+
     CONTENT_TYPE = 'Content-type'
     """Set the Content Type of a Response"""

--- a/commerce_coordinator/apps/stripe/pipeline.py
+++ b/commerce_coordinator/apps/stripe/pipeline.py
@@ -7,7 +7,7 @@ import logging
 from openedx_filters import PipelineStep
 from stripe.error import StripeError
 
-from commerce_coordinator.apps.core.constants import PaymentMethod
+from commerce_coordinator.apps.core.constants import PaymentMethod, PipelineCommand
 from commerce_coordinator.apps.stripe.clients import StripeAPIClient
 from commerce_coordinator.apps.stripe.constants import Currency
 from commerce_coordinator.apps.stripe.exceptions import (
@@ -41,9 +41,9 @@ class CreateOrGetStripeDraftPayment(PipelineStep):
             kwargs['payment_data']: optional. If present, skip this pipeline step.
         """
         if kwargs.get('payment_intent_data'):
-            return None  # Cancel rest of filter pipeline.
+            return PipelineCommand.HALT.value
         if kwargs.get('payment_data'):
-            return None  # Cancel rest of filter pipeline.
+            return PipelineCommand.HALT.value
 
         stripe_api_client = StripeAPIClient()
         try:
@@ -84,12 +84,12 @@ class GetStripeDraftPayment(PipelineStep):
         """
         # Payment intent already retrieved:
         if kwargs.get('payment_intent_data'):
-            return {}  # Skip pipeline step.
+            return PipelineCommand.CONTINUE.value
 
         # No existing payment:
         payment_data = kwargs.get('payment_data')
         if not payment_data:
-            return {}  # Skip pipeline step.
+            return PipelineCommand.CONTINUE.value
 
         payment_intent_id = payment_data['key_id']
 

--- a/commerce_coordinator/apps/titan/pipeline.py
+++ b/commerce_coordinator/apps/titan/pipeline.py
@@ -126,14 +126,18 @@ class ValidateOrderReadyForDraftPayment(PipelineStep):
         order_payment_state = order_data['payment_state']
 
         if order_payment_state not in correct_order_payment_states:
-            return None  # Order does not need draft payment. Halt pipeline.
+            logger.debug('Order does not need draft payment. Halt pipeline.')
+            return None
         elif not recent_payment:
-            return {}  # Continue. Will generate a new draft payment.
+            logger.debug('No draft payment found. Continue pipeline...')
+            return {}
         elif recent_payment['state'] == PaymentState.PENDING.value:
-            return None  # Order does not need draft payment. Halt pipeline.
+            logger.debug('Order already in progress. Halt pipeline.')
+            return None
         elif recent_payment['state'] == PaymentState.FAILED.value:
-            return {}  # Continue. Will generate a new draft payment.
-        # Inform pipeline that a draft payment already exists:
+            logger.debug('Failed payment found. Continue pipeline...')
+            return {}
+        logger.debug('Draft payment exists. Add draft payment to pipeline.')
         return {
             'payment_data': recent_payment
         }

--- a/commerce_coordinator/apps/titan/pipeline.py
+++ b/commerce_coordinator/apps/titan/pipeline.py
@@ -124,20 +124,27 @@ class ValidateOrderReadyForDraftPayment(PipelineStep):
 
         recent_payment = kwargs.get('recent_payment')
         order_payment_state = order_data['payment_state']
+        basket_id = order_data['basket_id']
 
         if order_payment_state not in correct_order_payment_states:
-            logger.debug('Order does not need draft payment. Halt pipeline.')
+            logger.debug('Order does not need draft payment. Halt pipeline for order: [%s]', basket_id)
             return PipelineCommand.HALT.value
         elif not recent_payment:
-            logger.debug('No draft payment found. Continue pipeline...')
+            logger.debug('No draft payment found. Continue pipeline for order: [%s]', basket_id)
             return PipelineCommand.CONTINUE.value
         elif recent_payment['state'] == PaymentState.PENDING.value:
-            logger.debug('Order already in progress. Halt pipeline.')
+            logger.debug('Payment [%s] already in progress. Halt pipeline for order: [%s]',
+                         recent_payment['payment_number'],
+                         basket_id)
             return PipelineCommand.HALT.value
         elif recent_payment['state'] == PaymentState.FAILED.value:
-            logger.debug('Failed payment found. Continue pipeline...')
+            logger.debug('Failed payment [%s] found. Continue pipeline for order: [%s]',
+                         recent_payment['payment_number'],
+                         basket_id)
             return PipelineCommand.CONTINUE.value
-        logger.debug('Draft payment exists. Add draft payment to pipeline.')
+        logger.debug('Draft payment [%s] exists. Add draft payment to pipeline for order: [%s]',
+                     recent_payment['payment_number'],
+                     basket_id)
         return {
             'payment_data': recent_payment
         }

--- a/commerce_coordinator/apps/titan/tests/test_pipeline.py
+++ b/commerce_coordinator/apps/titan/tests/test_pipeline.py
@@ -187,7 +187,10 @@ class TestValidateOrderReadyForDraftPayment(TestCase):
     @ddt.data(
         (
             # New order.
-            {'payment_state': OrderPaymentState.BALANCE_DUE.value},
+            {
+                'basket_id': ORDER_UUID,
+                'payment_state': OrderPaymentState.BALANCE_DUE.value,
+            },
             # No recent payment.
             None,
             # Pipeline continue.
@@ -195,18 +198,27 @@ class TestValidateOrderReadyForDraftPayment(TestCase):
         ),
         (
             # Failed payment.
-            {'payment_state': OrderPaymentState.FAILED.value},
+            {
+                'basket_id': ORDER_UUID,
+                'payment_state': OrderPaymentState.FAILED.value,
+            },
             # Failed recent payment.
-            {'state': PaymentState.FAILED.value},
+            {
+                'payment_number': 1234,
+                'state': PaymentState.FAILED.value},
             # Pipeline continue.
             {},
         ),
         (
             # Paid order.
-            {'payment_state': OrderPaymentState.PAID.value},
+            {
+                'basket_id': ORDER_UUID,
+                'payment_state': OrderPaymentState.PAID.value,
+            },
             # Completed recent payment.
             {
                 'key_id': 'pi_3Nfj5LH4caH7G0X11nX8dj9v',
+                'payment_number': 1234,
                 'state': PaymentState.COMPLETED.value,
             },
             # Pipeline halt.
@@ -214,10 +226,14 @@ class TestValidateOrderReadyForDraftPayment(TestCase):
         ),
         (
             # Order pending payment.
-            {'payment_state': OrderPaymentState.BALANCE_DUE.value},
+            {
+                'basket_id': ORDER_UUID,
+                'payment_state': OrderPaymentState.BALANCE_DUE.value,
+            },
             # Recent payment pending.
             {
                 'key_id': 'pi_3Nfj5LH4caH7G0X11nX8dj9v',
+                'payment_number': 1234,
                 'state': PaymentState.PENDING.value,
             },
             # Pipeline halt.
@@ -225,16 +241,21 @@ class TestValidateOrderReadyForDraftPayment(TestCase):
         ),
         (
             # Order pending payment.
-            {'payment_state': OrderPaymentState.BALANCE_DUE.value},
+            {
+                'basket_id': ORDER_UUID,
+                'payment_state': OrderPaymentState.BALANCE_DUE.value,
+            },
             # Recent payment exists.
             {
                 'key_id': 'pi_3Nfj5LH4caH7G0X11nX8dj9v',
+                'payment_number': 1234,
                 'state': PaymentState.CHECKOUT.value,
             },
             # Existing payment added to pipeline.
             {
                 'payment_data': {
                     'key_id': 'pi_3Nfj5LH4caH7G0X11nX8dj9v',
+                    'payment_number': 1234,
                     'state': PaymentState.CHECKOUT.value,
                 }
             },


### PR DESCRIPTION
## Description

Fix-forwards for https://github.com/edx/commerce-coordinator/pull/108:

- Add `PipelineCommand` Enum so it's clearer what `return {}` or `return None` is intended to do in the context of a `PipelineStep`.
- Add debug logging for ValidateOrderReadyForDraftPayment

## Additional Information

* Jira: [THES-215](https://2u-internal.atlassian.net/browse/THES-215)
* Fix-forwards: https://github.com/edx/commerce-coordinator/pull/108