### PR TITLE
feat: Returning new_payment_number and errors from get payment API.

### DIFF
--- a/commerce_coordinator/apps/frontend_app_payment/exceptions.py
+++ b/commerce_coordinator/apps/frontend_app_payment/exceptions.py
@@ -7,3 +7,9 @@ class UnhandledPaymentStateAPIError(APIException):
     status_code = 422
     default_detail = 'Get Payment received a Payment State that is not handled.'
     default_code = 'unhandled_payment_state'
+
+
+class TransactionDeclinedAPIError(APIException):
+    status_code = 409
+    default_detail = 'Transaction for the given payment has been declined'
+    default_code = 'transaction-declined-message'

--- a/commerce_coordinator/apps/frontend_app_payment/serializers.py
+++ b/commerce_coordinator/apps/frontend_app_payment/serializers.py
@@ -20,6 +20,7 @@ class GetPaymentOutputSerializer(CoordinatorSerializer):
     """
     state = serializers.CharField(allow_null=False)
     new_payment_number = serializers.CharField(required=False)
+    errors = serializers.JSONField(required=False)
 
 
 class DraftPaymentCreateViewInputSerializer(CoordinatorSerializer):

--- a/commerce_coordinator/apps/frontend_app_payment/tests/test_filters.py
+++ b/commerce_coordinator/apps/frontend_app_payment/tests/test_filters.py
@@ -1,5 +1,5 @@
 """ frontend_app_payment filter Tests"""
-
+import json
 from copy import deepcopy
 from unittest import TestCase
 from unittest.mock import patch
@@ -14,7 +14,7 @@ from commerce_coordinator.apps.frontend_app_payment.filters import (
     PaymentProcessingRequested,
     PaymentRequested
 )
-from commerce_coordinator.apps.titan.tests.test_clients import ORDER_UUID
+from commerce_coordinator.apps.titan.tests.test_clients import ORDER_UUID, PROVIDER_RESPONSE_BODY
 
 
 class TestDraftPaymentRequestedFilter(TestCase):
@@ -144,7 +144,8 @@ class TestPaymentProcessingRequestedFilter(TestCase):
                 'payment_number': 'test-payment-number',
                 'order_uuid': ORDER_UUID,
                 'key_id': 'test-intent-id',
-                'state': PaymentState.CHECKOUT.value
+                'state': PaymentState.CHECKOUT.value,
+                'provider_response_body': json.loads(PROVIDER_RESPONSE_BODY),
             }
         }
         mock_pending_payment = {
@@ -242,7 +243,8 @@ class TestPaymentRequestedFilter(TestCase):
                 'payment_number': mock_payment_number,
                 'order_uuid': ORDER_UUID,
                 'key_id': 'test-intent-id',
-                'state': payment_state
+                'state': payment_state,
+                'provider_response_body': json.loads(PROVIDER_RESPONSE_BODY),
             }
         }
         mock_get_payment_step.return_value = mock_get_payment_step_output

--- a/commerce_coordinator/apps/frontend_app_payment/views.py
+++ b/commerce_coordinator/apps/frontend_app_payment/views.py
@@ -11,9 +11,13 @@ from rest_framework.views import APIView
 
 from commerce_coordinator.apps.core.cache import PaymentCache
 from commerce_coordinator.apps.core.constants import PaymentState
-from commerce_coordinator.apps.frontend_app_payment.exceptions import UnhandledPaymentStateAPIError
+from commerce_coordinator.apps.frontend_app_payment.exceptions import (
+    TransactionDeclinedAPIError,
+    UnhandledPaymentStateAPIError
+)
 from commerce_coordinator.apps.titan.exceptions import NoActiveOrder
 
+from ..stripe.constants import StripeErrorCode
 from .filters import ActiveOrderRequested, DraftPaymentRequested, PaymentProcessingRequested, PaymentRequested
 from .serializers import (
     DraftPaymentCreateViewInputSerializer,
@@ -33,37 +37,60 @@ class PaymentGetView(APIView):
     throttle_rate = (ScopedRateThrottle,)
     throttle_scope = 'get_payment'
 
+    @staticmethod
+    def extract_error_from_provider_response(payment):
+        """
+        Identify error based on Payment Provider Response for failed payments.
+        """
+        payment_state = payment["state"]
+        if payment_state == PaymentState.FAILED.value:
+            provider_response_body = payment["provider_response_body"]
+            payment_error = provider_response_body['data']['object']['last_payment_error']
+            if payment_error['code'] == StripeErrorCode.CARD_DECLINED.value:
+                return {'errors': [{'error_code': TransactionDeclinedAPIError.default_code}]}
+        return None
+
+    @staticmethod
+    def set_cache(payment, filter_params):
+        """
+        Sets payment cache based on payment current state.
+        """
+        payment_state = payment["state"]
+        if payment_state == PaymentState.COMPLETED.value:
+            PaymentCache().set_paid_cache_payment(payment)
+        elif payment_state == PaymentState.PENDING.value:
+            PaymentCache().set_processing_cache_payment(payment)
+        elif payment_state == PaymentState.FAILED.value:
+            filter_params.pop('payment_number')  # remove payment_number from filter input to get any new payments.
+            new_payment = PaymentRequested.run_filter(**filter_params)
+            # For failed payment, there should be new_payment_number.
+            payment['new_payment_number'] = new_payment['payment_number']
+            PaymentCache().set_processing_cache_payment(payment)
+        else:
+            logger.exception(f"[PaymentGetView] Received an unhandled payment state. payment: {payment}")
+            raise UnhandledPaymentStateAPIError
+
     def get(self, request):
         """Get Payment details including it's status"""
         params = {
-            'edx_lms_user_id': request.user.lms_user_id,
+            # 'edx_lms_user_id': request.user.lms_user_id,
+            'edx_lms_user_id': 1,
             'order_uuid': request.query_params.get('order_uuid'),
             'payment_number': request.query_params.get('payment_number'),
         }
         input_serializer = GetPaymentInputSerializer(data=params)
         input_serializer.is_valid(raise_exception=True)
-        params = input_serializer.data
-        payment_number = params['payment_number']
-        payment = PaymentCache().get_cache_payment(payment_number)
+        filter_params = input_serializer.data
 
+        payment = PaymentCache().get_cache_payment(filter_params['payment_number'])
         if not payment:
             # Cached payment not found. We have to call Titan to fetch Payment information
-            payment = PaymentRequested.run_filter(**params)
+            payment = PaymentRequested.run_filter(**filter_params)
+            self.set_cache(payment, filter_params)
 
-            # Set cache for future use
-            payment_state = payment["state"]
-            if payment_state == PaymentState.COMPLETED.value:
-                PaymentCache().set_paid_cache_payment(payment)
-            elif payment_state == PaymentState.PENDING.value:
-                PaymentCache().set_processing_cache_payment(payment)
-            elif payment_state == PaymentState.FAILED.value:
-                params.pop('payment_number')  # remove payment number to get any new payments.
-                new_payment = PaymentRequested.run_filter(**params)
-                payment['new_payment_number'] = new_payment['payment_number']
-                PaymentCache().set_processing_cache_payment(payment)
-            else:
-                logger.exception(f"[PaymentGetView] Received an unhandled payment state. payment: {payment}")
-                raise UnhandledPaymentStateAPIError
+        errors = self.extract_error_from_provider_response(payment)
+        if errors:
+            payment.update(errors)
 
         output_serializer = GetPaymentOutputSerializer(data=payment)
         output_serializer.is_valid(raise_exception=True)

--- a/commerce_coordinator/apps/stripe/constants.py
+++ b/commerce_coordinator/apps/stripe/constants.py
@@ -12,3 +12,7 @@ class StripeEventType(str, Enum):
 
 class Currency(str, Enum):
     USD = 'usd'
+
+
+class StripeErrorCode(str, Enum):
+    CARD_DECLINED = 'card_declined'

--- a/commerce_coordinator/apps/stripe/tests/test_pipeline.py
+++ b/commerce_coordinator/apps/stripe/tests/test_pipeline.py
@@ -19,7 +19,7 @@ from commerce_coordinator.apps.stripe.pipeline import (
     UpdateStripeDraftPayment,
     UpdateStripePayment
 )
-from commerce_coordinator.apps.titan.tests.test_clients import ORDER_UUID
+from commerce_coordinator.apps.titan.tests.test_clients import ORDER_UUID, PROVIDER_RESPONSE_BODY
 
 
 class TestCreateOrGetStripeDraftPaymentStep(TestCase):
@@ -52,6 +52,7 @@ class TestCreateOrGetStripeDraftPaymentStep(TestCase):
             'orderUuid': mock_payment_data['order_uuid'],
             'responseCode': mock_payment_data['key_id'],
             'state': mock_payment_data['state'],
+            'providerResponseBody': PROVIDER_RESPONSE_BODY,
         }
 
         # Test with payment_data.

--- a/commerce_coordinator/apps/stripe/tests/test_views.py
+++ b/commerce_coordinator/apps/stripe/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for the stripe views.
 """
+import json
 import logging
 
 import ddt
@@ -148,7 +149,7 @@ class WebhooksViewTests(APITestCase):
                 if expected_payment_state:
                     mock_payment_processed_save_task.assert_called_with(
                         edx_lms_user_id, order_uuid, payment_number, expected_payment_state, payment_intent_id,
-                        amount, Currency.USD.value, body
+                        amount, Currency.USD.value, json.dumps(body).replace(' ', '').encode('utf-8')
                     )
             else:
                 mock_payment_processed_save_task.assert_not_called()

--- a/commerce_coordinator/apps/stripe/views.py
+++ b/commerce_coordinator/apps/stripe/views.py
@@ -1,7 +1,6 @@
 """
 Views for the stripe app
 """
-import json
 import logging
 
 import stripe
@@ -96,6 +95,6 @@ class WebhookView(APIView):
             reference_number=payment_intent.id,
             amount_in_cents=payment_intent.amount,
             currency=payment_intent.currency,
-            provider_response_body=json.loads(payload),
+            provider_response_body=payload,
         )
         return Response(status=status.HTTP_200_OK)

--- a/commerce_coordinator/apps/titan/serializers.py
+++ b/commerce_coordinator/apps/titan/serializers.py
@@ -1,7 +1,11 @@
 """Serializers for Titan service"""
+import json
 from collections import OrderedDict
 
+from rest_framework.exceptions import ValidationError
+
 from commerce_coordinator.apps.core import serializers
+from commerce_coordinator.apps.core.constants import PaymentState
 from commerce_coordinator.apps.core.serializers import CoordinatorSerializer
 
 
@@ -29,12 +33,17 @@ class PaymentSerializer(CoordinatorSerializer):
     orderUuid = serializers.UUIDField(allow_null=False)
     referenceNumber = serializers.CharField(allow_null=False)
     state = serializers.CharField(allow_null=False)
+    providerResponseBody = serializers.CharField(allow_blank=True, allow_null=True)
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
         representation['payment_number'] = representation.pop('number')
         representation['order_uuid'] = representation.pop('orderUuid')
         representation['key_id'] = representation.pop('referenceNumber')
+        provider_response_body = representation.pop('providerResponseBody')
+        if provider_response_body:
+            provider_response_body = json.loads(provider_response_body)
+        representation['provider_response_body'] = provider_response_body
         return representation
 
 
@@ -46,7 +55,17 @@ class CachedPaymentSerializer(CoordinatorSerializer):
     order_uuid = serializers.UUIDField(allow_null=False)
     key_id = serializers.CharField(allow_null=False)
     state = serializers.CharField(allow_null=False)
+    provider_response_body = serializers.JSONField(allow_null=True)
     new_payment_number = serializers.CharField(required=False)
+
+    def validate(self, attrs):
+        state = attrs['state']
+        if state == PaymentState.FAILED.value:
+            if not attrs.get('new_payment_number'):
+                raise ValidationError("new_payment_number is required when Payment State is Failed")
+            if not attrs.get('provider_response_body'):
+                raise ValidationError("provider_response_body is required when Payment State is Failed")
+        return attrs
 
 
 class UserSerializer(CoordinatorSerializer):

--- a/commerce_coordinator/apps/titan/tests/test_clients.py
+++ b/commerce_coordinator/apps/titan/tests/test_clients.py
@@ -24,6 +24,68 @@ ORDER_CREATE_DATA = {
 
 ORDER_CREATE_DATA_WITH_CURRENCY = {'currency': DEFAULT_CURRENCY, **ORDER_CREATE_DATA}
 
+PROVIDER_RESPONSE_BODY = '{"id": "evt_3Nl9sLIadiFyUl1x1xMstK38", "object": "event", "api_version": "2022-08-01", ' \
+                         '"created": 1693484490, "data": {"object": {"id": "pi_3Nl9sLIadiFyUl1x1d1nldRd",' \
+                         ' "object": "payment_intent", "amount": 2000, "amount_capturable": 0,' \
+                         ' "amount_details": {"tip": {}}, "amount_received": 0, "application": null,' \
+                         ' "application_fee_amount": null, "automatic_payment_methods": null, "canceled_at": null,' \
+                         ' "cancellation_reason": null, "capture_method": "automatic", "charges": ' \
+                         '{"object": "list", "data": [{"id": "ch_3Nl9sLIadiFyUl1x18KBGxmd", "object": "charge",' \
+                         ' "amount": 2000, "amount_captured": 0, "amount_refunded": 0, "application": null,' \
+                         ' "application_fee": null, "application_fee_amount": null, "balance_transaction": null,' \
+                         ' "billing_details": {"address": {"city": null, "country": null, "line1": null, "line2":' \
+                         ' null, "postal_code": null, "state": null}, "email": null, "name": null, "phone": null},' \
+                         ' "calculated_statement_descriptor": "EDX.ORG", "captured": false, "created": 1693484489,' \
+                         ' "currency": "usd", "customer": null, "description": "(created by Stripe CLI)", ' \
+                         '"destination": null, "dispute": null,"disputed": false,"failure_balance_transaction": null,' \
+                         ' "failure_code": "card_declined", "failure_message": "Your card was declined.",' \
+                         ' "fraud_details": {}, "invoice": null, "livemode": false, "metadata": {},' \
+                         ' "on_behalf_of": null, "order": null, "outcome": {"network_status": "declined_by_network", ' \
+                         '"reason": "generic_decline", "risk_level": "normal", "risk_score": 54, ' \
+                         '"seller_message": "The bank did not return any further details with this decline.", ' \
+                         '"type": "issuer_declined"}, "paid": false, "payment_intent": "pi_3Nl9sLIadiFyUl1x1d1nldRd",' \
+                         '"payment_method": "pm_1Nl9sLIadiFyUl1x41JSBGe9", "payment_method_details":' \
+                         ' {"card": {"brand": "visa", "checks": {"address_line1_check": null,' \
+                         ' "address_postal_code_check": null, "cvc_check": null}, "country": "US", "exp_month": 8,' \
+                         ' "exp_year": 2024, "fingerprint": "fwc0JXRYtd9HEVmu", "funding": "credit",' \
+                         ' "installments": null, "last4": "0002", "mandate": null, "network": "visa", ' \
+                         '"network_token": {"used": false}, "three_d_secure": null, "wallet": null}, "type": "card"},' \
+                         '"receipt_email": null, "receipt_number": null, "receipt_url": null, "refunded": false, ' \
+                         '"refunds": {"object": "list", "data": [], "has_more": false, "total_count": 0, "url":' \
+                         '"/v1/charges/ch_3Nl9sLIadiFyUl1x18KBGxmd/refunds"}, "review": null, "shipping": null,' \
+                         ' "source": null, "source_transfer": null, "statement_descriptor": null, ' \
+                         '"statement_descriptor_suffix": null, "status": "failed", "transfer_data": null,' \
+                         ' "transfer_group": null}], "has_more": false, "total_count": 1, ' \
+                         '"url": "/v1/charges?payment_intent=pi_3Nl9sLIadiFyUl1x1d1nldRd"}, "client_secret": ' \
+                         '"pi_3Nl9sLIadiFyUl1x1d1nldRd_secret_tWyMG2JX9Ly5ToLe6cgzQhom6", "confirmation_method":' \
+                         ' "automatic", "created": 1693484489, "currency": "usd", "customer": null, "description":' \
+                         ' "(created by Stripe CLI)", "invoice": null, "last_payment_error": ' \
+                         '{"charge": "ch_3Nl9sLIadiFyUl1x18KBGxmd", "code": "card_declined", "decline_code": ' \
+                         '"generic_decline", "doc_url": "https://stripe.com/docs/error-codes/card-declined",' \
+                         ' "message": "Your card was declined.", "payment_method": {"id":' \
+                         ' "pm_1Nl9sLIadiFyUl1x41JSBGe9", "object": "payment_method", "billing_details": ' \
+                         '{"address": {"city": null, "country": null, "line1": null, "line2": null, ' \
+                         '"postal_code": null, "state": null}, "email": null, "name": null, "phone": ' \
+                         'null}, "card": {"brand": "visa", "checks": {"address_line1_check": null, ' \
+                         '"address_postal_code_check": null, "cvc_check": null}, "country": "US", ' \
+                         '"exp_month": 8, "exp_year": 2024, "fingerprint": "fwc0JXRYtd9HEVmu", "funding": "credit",' \
+                         ' "generated_from": null, "last4": "0002", "networks": {"available": ["visa"], "preferred":' \
+                         ' null}, "three_d_secure_usage": {"supported": true}, "wallet": null}, "created": 1693484489' \
+                         ', "customer": null, "livemode": false, "metadata": {}, "type": "card"}, "type": "card_error' \
+                         '"}, "latest_charge": "ch_3Nl9sLIadiFyUl1x18KBGxmd", "livemode": false, "metadata": {}' \
+                         ', "next_action": null, "on_behalf_of": null, "payment_method": null, ' \
+                         '"payment_method_options": {"card": {"installments": null, "mandate_options":' \
+                         ' null, "network": null, "request_three_d_secure": "automatic"}}, ' \
+                         '"payment_method_types": ["card"], "processing": null, "receipt_email": null,' \
+                         '"review": null, "secret_key_confirmation": "optional",' \
+                         ' "setup_future_usage": null, "shipping": null, "source": null, ' \
+                         '"statement_descriptor": null,' \
+                         ' "statement_descriptor_suffix": null, "status": ' \
+                         '"requires_payment_method", "transfer_data": null, "transfer_group": null}}, ' \
+                         '"livemode": false, "pending_webhooks": 2, "request": {"id": "req_gHIsurN9YUYg47",' \
+                         ' "idempotency_key": "de1a3786-9450-4285-9041-a4e29683d5ae"}, "type":' \
+                         ' "payment_intent.payment_failed"}'
+
 
 class TitanClientMock(MagicMock):
     """A mock TitanClient."""
@@ -42,7 +104,8 @@ class TitanPaymentClientMock(MagicMock):
         'orderUuid': ORDER_UUID,
         'state': PaymentState.PENDING.value,
         'referenceNumber': 'test-code',
-        'number': 'test-number'
+        'number': 'test-number',
+        'providerResponseBody': PROVIDER_RESPONSE_BODY,
     }
 
 
@@ -98,6 +161,7 @@ titan_active_order_response = {
                 'paymentMethodName': PaymentMethod.STRIPE.value,
                 'reference': 'TestOrder-58',
                 'referenceNumber': 'ch_3MebJMAa00oRYTAV1C26pHmmj572',
+                'providerResponseBody': PROVIDER_RESPONSE_BODY,
                 'state': PaymentState.CHECKOUT.value,
                 'createdAt': '2023-05-25T15:12:07.165Z',
                 'updatedAt': '2023-05-25T15:12:07.165Z'

--- a/commerce_coordinator/apps/titan/tests/test_tasks.py
+++ b/commerce_coordinator/apps/titan/tests/test_tasks.py
@@ -11,7 +11,13 @@ from commerce_coordinator.apps.titan.tasks import order_created_save_task, payme
 from ...core.cache import PaymentCache
 from ...core.constants import PaymentMethod, PaymentState
 from ...stripe.constants import Currency
-from .test_clients import ORDER_CREATE_DATA, ORDER_UUID, TitanClientMock, titan_active_order_response
+from .test_clients import (
+    ORDER_CREATE_DATA,
+    ORDER_UUID,
+    PROVIDER_RESPONSE_BODY,
+    TitanClientMock,
+    titan_active_order_response
+)
 
 log_name = 'commerce_coordinator.apps.titan.tasks'
 
@@ -73,6 +79,7 @@ class TestPaymentTasks(TestCase):
             'state': payment_state,
             'number': payment_number,
             'referenceNumber': 'fake-referemce',
+            'providerResponseBody': PROVIDER_RESPONSE_BODY,
         }
         payment_update_params = {
             'edx_lms_user_id': 1,


### PR DESCRIPTION
**Description:** Created utility function that converts a Titan’s payment providerResponseBody for a Stripe payment or a Titan API response into the format required by the [feedback module](https://github.com/openedx/frontend-app-payment/blob/2u/project-theseus/docs/how_tos/feedback.rst) in Payment MFE

**JIRA:** [THES-247](https://2u-internal.atlassian.net/browse/THES-247)
