### PR TITLE
fix: remove JWT_AUTH_REFRESH_COOKIE

### DIFF
--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -232,7 +232,6 @@ JWT_AUTH = {
     'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
 }
 
 # Request the user's permissions in the ID token


### PR DESCRIPTION
**Description:** 

Remove unused JWT_AUTH_REFRESH_COOKIE setting. This setting was never actually used, so there is no timing issues.

See DEPR for details:
https://github.com/openedx/public-engineering/issues/190