### PR TITLE
fix: [SONIC-169] add git & alphabetize installed packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,35 +4,28 @@ MAINTAINER sre@edx.org
 
 # Packages installed:
 
-# language-pack-en locales; ubuntu locale support so that system utilities have a consistent
-# language and time zone.
-
-# python; ubuntu doesnt ship with python, so this is the python we will use to run the application
-
-# python3-pip; install pip to install application requirements.txt files
-
-# libmysqlclient-dev; to install header files needed to use native C implementation for
-# MySQL-python for performance gains.
-
-# libssl-dev; # mysqlclient wont install without this.
-
-# python3-dev; to install header files for python extensions; much wheel-building depends on this
-
 # gcc; for compiling python extensions distributed with python packages like mysql-client
-
+# git; for pulling requirements from GitHub.
+# language-pack-en locales; ubuntu locale support so that system utilities have a consistent language and time zone.
+# libmysqlclient-dev; to install header files needed to use native C implementation for MySQL-python for performance gains.
+# libssl-dev; # mysqlclient wont install without this.
 # pkg-config is now required for libmysqlclient-dev and its python dependencies
+# python3-dev; to install header files for python extensions; much wheel-building depends on this
+# python3-pip; install pip to install application requirements.txt files
+# python; ubuntu doesnt ship with python, so this is the python we will use to run the application
 
 # If you add a package here please include a comment above describing what it is used for
 RUN apt-get update && apt-get -qy install --no-install-recommends \
+ gcc \
+ git \
  language-pack-en \
- locales \
- python3.8 \
- python3-pip \
  libmysqlclient-dev \
- pkg-config \
  libssl-dev \
+ locales \
+ pkg-config \
  python3-dev \
- gcc
+ python3-pip \
+ python3.8 \
 
 
 RUN pip install --upgrade pip setuptools


### PR DESCRIPTION
## Description

Add git & alphabetize installed packages in Dockerfile.

Due to following error on deploy:

    Collecting commercetools@ git+https://github.com/edx/commercetools-python-sdk.git@36639f4a196d7fc0daecf914ee46f42229087abb (from -r requirements/production.txt (line 70))
      Cloning https://github.com/edx/commercetools-python-sdk.git (to revision 36639f4a196d7fc0daecf914ee46f42229087abb) to /tmp/pip-install-u2dcvnx4/commercetools_cdad0154d7824963bfdfe8c00e11493f
      ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git version
    ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
    The command '/bin/sh -c pip install -r requirements/production.txt' returned a non-zero code: 1

We need this because we use a fork of edx/commercetools-python-sdk that is not published to PyPI.

## Additional Information

* Jira: [SONIC-169](https://2u-internal.atlassian.net/browse/SONIC-169)