### PR TITLE
feat: [SONIC-117] Add source system to ct fulfillment and update ct fulfillment tests

### DIFF
--- a/commerce_coordinator/apps/commercetools/serializers.py
+++ b/commerce_coordinator/apps/commercetools/serializers.py
@@ -42,4 +42,5 @@ class OrderFulfillViewInputSerializer(CoordinatorSerializer):
     email_opt_in = serializers.BooleanField(allow_null=False)
     order_number = serializers.CharField(allow_null=False)
     provider_id = serializers.CharField(allow_null=True)
+    source_system = serializers.CharField(allow_null=False)
     edx_lms_user_id = serializers.IntegerField(allow_null=False)

--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -1,0 +1,6 @@
+"""
+commercetools signals and receivers.
+"""
+from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal
+
+fulfill_order_placed_signal = CoordinatorSignal()

--- a/commerce_coordinator/apps/commercetools/tests/constants.py
+++ b/commerce_coordinator/apps/commercetools/tests/constants.py
@@ -1,0 +1,61 @@
+'''Constants for commercetools tests'''
+from datetime import datetime
+
+import pytz
+
+from commerce_coordinator.apps.commercetools.views import OrderFulfillView
+
+EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE = {
+    'version': '0',
+    'id': 'aaaaaaaa-8888-00ee-aaaa-aaaaaaaaaaaa',
+    'detail-type': 'OrderStateChanged',
+    'source': 'aws.partner/commercetools.com/2u-marketplace-dev-01/commerce-coordinator-eventbridge',
+    'account': '835688427423',
+    'time': '2023-11-21T13:21:11Z',
+    'region': 'us-east-2',
+    'resources': [],
+    'detail': {
+        'notificationType': 'Message',
+        'projectKey': '2u-marketplace-dev-01',
+        'id': '3cbbbbbb-ce15-4979-aaca-bb121bbbbbbb',
+        'version': 1,
+        'sequenceNumber': 57,
+        'resource': {
+            'typeId': 'order',
+            'id': '9e60e10b-861c-40b0-afa4-c769dcccccc1'
+        },
+        'resourceVersion': 58,
+        'type': 'OrderStateChanged',
+        'orderId': '9e60e10b-861c-40b0-afa4-c769dcccccc1',
+        'orderState': 'Complete',
+        'oldOrderState': 'Cancelled',
+        'createdAt': '2023-11-21T13:21:11.122Z',
+        'lastModifiedAt': '2023-11-21T13:21:11.122Z',
+        'createdBy': {
+            'isPlatformClient': True,
+            'user': {
+                'typeId': 'user',
+                'id': '5daf67fd-15a6-4d77-9149-01413dddddd3'
+            },
+        },
+        'lastModifiedBy': {
+            'isPlatformClient': True,
+            'user': {
+                'typeId': 'user',
+                'id': '5daf67fd-15a6-4d77-9149-01413dddddd3'
+            },
+        },
+    },
+}
+
+EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD = {
+    'sender': OrderFulfillView,
+    'course_id': 'course-v1:edX+DemoX+Demo_Course',
+    'course_mode': 'verified',
+    'date_placed': datetime(2023, 10, 31, 19, 56, 36, 957000, tzinfo=pytz.utc),
+    'edx_lms_user_id': 127,
+    'email_opt_in': True,
+    'order_number': 'c1f1961f-7dac-4ec6-a0ff-364b71c082b6',
+    'provider_id': None,
+    'source_system': 'commercetools',
+}

--- a/commerce_coordinator/apps/commercetools/tests/test_views.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_views.py
@@ -1,86 +1,124 @@
 """Tests for the commercetools views"""
 
+from unittest.mock import MagicMock, patch
+
 import ddt
 from django.urls import reverse
-from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APIClient, APITestCase
 
-from commerce_coordinator.apps.core.tests.utils import name_test
+from commerce_coordinator.apps.commercetools.tests.conftest import gen_customer, gen_order
+from commerce_coordinator.apps.commercetools.tests.constants import (
+    EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE,
+    EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD
+)
+from commerce_coordinator.apps.core.models import User
+from commerce_coordinator.apps.core.signal_helpers import format_signal_results
+
+
+class FulfillOrderPlacedSignalMock(MagicMock):
+    """
+    A mock fulfill_order_placed_signal that always returns
+    EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD in the shape of format_signal_results.
+    """
+
+    def mock_receiver(self):
+        pass  # pragma: no cover
+
+    return_value = [
+        (mock_receiver, 'bogus_task_id'),
+    ]
+
+
+class CTOrderByIdMock(MagicMock):
+    """
+    A mock get_order_by_id call that always returns
+    EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD in the shape of format_signal_results.
+    """
+    return_value = gen_order(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD['order_number'])
+
+
+class CTCustomerByIdMock(MagicMock):
+    """
+    A mock get_customer_by_id call that always returns
+    EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD in the shape of format_signal_results.
+    """
+    return_value = gen_customer("hiya@text.example", "jim_34")
 
 
 @ddt.ddt
+@patch('commerce_coordinator.apps.commercetools.views.fulfill_order_placed_signal.send_robust',
+       new_callable=FulfillOrderPlacedSignalMock)
+@patch(
+        'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_order_by_id',
+        new_callable=CTOrderByIdMock
+    )
+@patch(
+        'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_customer_by_id',
+        new_callable=CTCustomerByIdMock
+    )
 class OrderFulfillViewTests(APITestCase):
+    # Disable unused-argument due to global @patch
+    # pylint: disable=unused-argument
     "Tests for order fulfill view"
     url = reverse('commercetools:fulfill')
 
-    @ddt.data(
-        # name_test("test success", (
-        #     {}, None, status.HTTP_200_OK,
-        #     {}
-        # )),
-        name_test("test no details", (
-            {}, 'detail', status.HTTP_400_BAD_REQUEST,
-            {'error_key': 'detail', 'error_message': 'This field is required.'}
-        ))
-    )
-    @ddt.unpack
-    def test_fulfill_view(self, update_params, skip_params, expected_status, expected_error):
-        message = {
-            'version': '0',
-            'id': 'aaaaaaaa-8888-00ee-aaaa-aaaaaaaaaaaa',
-            'detail-type': 'OrderStateChanged',
-            'source': 'aws.partner/commercetools.com/2u-marketplace-dev-01/commerce-coordinator-eventbridge',
-            'account': '835688427423',
-            'time': '2023-11-21T13:21:11Z',
-            'region': 'us-east-2',
-            'resources': [],
-            'detail': {
-                'notificationType': 'Message',
-                'projectKey': '2u-marketplace-dev-01',
-                'id': '3cbbbbbb-ce15-4979-aaca-bb121bbbbbbb',
-                'version': 1,
-                'sequenceNumber': 57,
-                'resource': {
-                    'typeId': 'order',
-                    'id': '9e60e10b-861c-40b0-afa4-c769dcccccc1'
-                },
-                'resourceVersion': 58,
-                'type': 'OrderStateChanged',
-                'orderId': '9e60e10b-861c-40b0-afa4-c769dcccccc1',
-                'orderState': 'Complete',
-                'oldOrderState': 'Cancelled',
-                'createdAt': '2023-11-21T13:21:11.122Z',
-                'lastModifiedAt': '2023-11-21T13:21:11.122Z',
-                'createdBy': {
-                    'isPlatformClient': True,
-                    'user': {
-                        'typeId': 'user',
-                        'id': '5daf67fd-15a6-4d77-9149-01413dddddd3'
-                    },
-                },
-                'lastModifiedBy': {
-                    'isPlatformClient': True,
-                    'user': {
-                        'typeId': 'user',
-                        'id': '5daf67fd-15a6-4d77-9149-01413dddddd3'
-                    },
-                },
-            },
-        }
+    # Use Django Rest Framework client for self.client
+    client_class = APIClient
 
-        message.update(update_params)
+    # Define test user properties
+    test_user_username = 'test_user'
+    test_staff_username = 'test_staff_user'
+    test_password = 'test_password'
 
-        if skip_params:
-            del message[skip_params]
+    def setUp(self):
+        """Create test user before test starts."""
 
-        response = self.client.post(self.url, data=message, format="json")
-        self.assertEqual(response.status_code, expected_status)
-        if expected_status != status.HTTP_200_OK:
-            response_json = response.json()
-            expected_error_key = expected_error['error_key']
-            expected_error_message = expected_error['error_message']
-            self.assertIn(expected_error_key, response_json)
-            self.assertIn(expected_error_message, response_json[expected_error_key])
+        super().setUp()
+
+        User.objects.create_user(username=self.test_user_username, password=self.test_password)
+        User.objects.create_user(username=self.test_staff_username, password=self.test_password,  is_staff=True)
+
+    def tearDown(self):
+        """Log out any user from client after test ends."""
+
+        super().tearDown()
+        self.client.logout()
+
+    def test_view_returns_ok(self, mock_customer, mock_order, mock_signal):
+        """Check authorized user requesting fulfillment receives a HTTP 200 OK."""
+
+        # Login
+        self.client.login(username=self.test_staff_username, password=self.test_password)
+
+        # Send request
+        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE, format='json')
+
+        # Check 200 OK
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_sends_expected_signal_parameters(self, mock_customer, mock_order, mock_signal):
+        """Check view sends expected signal parameters."""
+        # Login
+        self.client.login(username=self.test_staff_username, password=self.test_password)
+
+        # Send request
+        self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE, format='json')
+
+        # Check expected response
+        mock_signal.assert_called_once_with(**EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD)
+
+    def test_view_returns_expected_response(self, mock_customer, mock_order, mock_signal):
+        """Check authorized account requesting fulfillment receives an expected response."""
+
+        # Login
+        self.client.login(username=self.test_staff_username, password=self.test_password)
+
+        # Send request
+        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE, format='json')
+        # Check expected response
+        expected_response = format_signal_results(FulfillOrderPlacedSignalMock.return_value)
+        self.assertEqual(response.json(), expected_response)
+
 
 # """ Commercetools Order History testcases """
 # from unittest.mock import MagicMock, patch

--- a/commerce_coordinator/apps/commercetools/tests/test_views.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_views.py
@@ -119,6 +119,35 @@ class OrderFulfillViewTests(APITestCase):
         expected_response = format_signal_results(FulfillOrderPlacedSignalMock.return_value)
         self.assertEqual(response.json(), expected_response)
 
+    def test_view_returns_expected_error(self, mock_customer, mock_order, mock_signal):
+        """Check authorized account requesting fulfillment with bad inputs receive an expected error."""
+
+        # Login
+        self.client.login(username=self.test_staff_username, password=self.test_password)
+
+        # Add errors to example request
+        payload_with_errors = EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE.copy()
+        payload_with_errors.pop('detail')
+
+        # Send request
+        response = self.client.post(self.url, data=payload_with_errors, format='json')
+
+        # Check expected response
+        expected_response = {
+            'detail': ['This field is required.'],
+        }
+        self.assertEqual(response.json(), expected_response)
+
+    def test_view_returns_expected_error_no_order(self, mock_customer, mock_order, mock_signal):
+        """Check authorized account requesting fulfillment unable to get customer receive an expected error."""
+        mock_customer.return_value = None
+        # Login
+        self.client.login(username=self.test_staff_username, password=self.test_password)
+
+        # Send request
+        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE, format='json')
+
+        self.assertEqual(response.status_code, 200)
 
 # """ Commercetools Order History testcases """
 # from unittest.mock import MagicMock, patch

--- a/commerce_coordinator/apps/lms/signals.py
+++ b/commerce_coordinator/apps/lms/signals.py
@@ -24,5 +24,6 @@ def fulfill_order_placed_send_enroll_in_course(**kwargs):
         email_opt_in=kwargs['email_opt_in'],
         order_number=kwargs['order_number'],
         provider_id=kwargs['provider_id'],
+        source_system=kwargs['source_system'],
     )
     return async_result.id

--- a/commerce_coordinator/apps/lms/tests/constants.py
+++ b/commerce_coordinator/apps/lms/tests/constants.py
@@ -11,6 +11,7 @@ EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD: Dict[str, Union[str, bool, int, None]] = {
     'email_opt_in': False,
     'order_number': '61ec1afa-1b0e-4234-ae28-f997728054fa',
     'provider_id': None,
+    'source_system': 'test',
 }
 
 EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD = {
@@ -31,6 +32,11 @@ EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD = {
             'namespace': 'order',
             'name': 'order_placed',
             'value': '2023-04-17T13:30:33Z'
+        },
+        {
+            'namespace': 'order',
+            'name': 'source_system',
+            'value': 'test'
         }
     ]
 }

--- a/commerce_coordinator/apps/lms/tests/test_signals.py
+++ b/commerce_coordinator/apps/lms/tests/test_signals.py
@@ -29,6 +29,7 @@ class FulfillOrderPlacedSendEnrollInCourseTest(CoordinatorSignalReceiverTestCase
         'email_opt_in': 5,
         'order_number': 6,
         'provider_id': 7,
+        'source_system': 8,
     }
 
     def test_correct_arguments_passed(self, mock_task):

--- a/commerce_coordinator/apps/lms/tests/test_tasks.py
+++ b/commerce_coordinator/apps/lms/tests/test_tasks.py
@@ -37,7 +37,8 @@ class FulfillOrderPlacedSendEnrollInCourseTaskTest(TestCase):
             values['edx_lms_user_id'],
             values['email_opt_in'],
             values['order_number'],
-            values['provider_id']
+            values['provider_id'],
+            values['source_system']
         )
 
     def setUp(self):

--- a/commerce_coordinator/apps/titan/serializers.py
+++ b/commerce_coordinator/apps/titan/serializers.py
@@ -20,6 +20,7 @@ class OrderFulfillViewInputSerializer(CoordinatorSerializer):
     email_opt_in = serializers.BooleanField(allow_null=False)
     order_number = serializers.UUIDField(allow_null=False)
     provider_id = serializers.CharField(allow_null=True)
+    source_system = serializers.CharField(allow_null=False)
 
 
 class PaymentSerializer(CoordinatorSerializer):

--- a/commerce_coordinator/apps/titan/tests/constants.py
+++ b/commerce_coordinator/apps/titan/tests/constants.py
@@ -14,6 +14,7 @@ EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD = {
     'edx_lms_user_id': 4,
     'email_opt_in': 0,
     'order_number': '61ec1afa-1b0e-4234-ae28-f997728054fa',
+    'source_system': 'titan',
 }
 
 EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD = {
@@ -25,4 +26,5 @@ EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD = {
     'email_opt_in': False,
     'order_number': UUID('61ec1afa-1b0e-4234-ae28-f997728054fa'),
     'provider_id': None,
+    'source_system': 'titan',
 }

--- a/commerce_coordinator/apps/titan/views.py
+++ b/commerce_coordinator/apps/titan/views.py
@@ -15,6 +15,7 @@ from .serializers import OrderFulfillViewInputSerializer
 from .signals import fulfill_order_placed_signal
 
 logger = logging.getLogger(__name__)
+SOURCE_SYSTEM = 'titan'
 
 
 class OrderFulfillView(APIView):
@@ -56,6 +57,7 @@ class OrderFulfillView(APIView):
             'email_opt_in': request.data.get('email_opt_in'),
             'order_number': request.data.get('order_number'),
             'provider_id': request.data.get('provider'),
+            'source_system': SOURCE_SYSTEM,
         }
 
         # TODO: add enterprise data for enrollment API here

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -330,9 +330,9 @@ CC_SIGNALS = {
     'commerce_coordinator.apps.stripe.signals.payment_processed_signal': [
         'commerce_coordinator.apps.titan.signals.payment_processed_save',
     ],
-    # 'commerce_coordinator.apps.commercetools.signals.fulfill_order_placed_signal': [
-    #     'commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course',
-    # ],
+    'commerce_coordinator.apps.commercetools.signals.fulfill_order_placed_signal': [
+        'commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course',
+    ],
 }
 
 # Default timeouts for requests

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -330,6 +330,9 @@ CC_SIGNALS = {
     'commerce_coordinator.apps.stripe.signals.payment_processed_signal': [
         'commerce_coordinator.apps.titan.signals.payment_processed_save',
     ],
+    # 'commerce_coordinator.apps.commercetools.signals.fulfill_order_placed_signal': [
+    #     'commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course',
+    # ],
 }
 
 # Default timeouts for requests


### PR DESCRIPTION
[SONIC-117](https://2u-internal.atlassian.net/browse/SONIC-117)

This PR adds unit tests for the fulfillment view added in [SONIC-120](https://2u-internal.atlassian.net/browse/SONIC-120)

It also adds a new source_system attribute to the fulfillment lms call

Added config for commercetools signal
