### PR TITLE
feat: Added client that checks for enterprise users

### DIFF
--- a/commerce_coordinator/apps/enterprise_learner/enterprise_client.py
+++ b/commerce_coordinator/apps/enterprise_learner/enterprise_client.py
@@ -1,0 +1,45 @@
+"""
+API client for calls to Enterprise Service.
+"""
+import logging
+
+from django.conf import settings
+from requests.exceptions import ConnectionError, HTTPError, Timeout  # pylint: disable=redefined-builtin
+
+from commerce_coordinator.apps.core.clients import BaseEdxOAuthClient
+
+logger = logging.getLogger(__name__)
+
+
+class EnterpriseApiClient(BaseEdxOAuthClient):
+    """
+    API client for calls to the Enterprise Service.
+    """
+    enterprise_api_base_url = f"{settings.ENTERPRISE_URL}/enterprise/api/v1"
+    enterprise_customer_info_endpoint = f"{enterprise_api_base_url}/enterprise-learner"
+
+    def check_user_is_enterprise_customer(self, username):
+        """
+        Checks if the user is an enterprise customer.
+        Arguments:
+            username (string): Username of the user
+        Returns:
+            is_enterprise_user (Boolean) : True if the user is an enterprise customer else False
+        """
+        try:
+            response = self.client.get(self.enterprise_customer_info_endpoint,
+                                       timeout=settings.ENTERPRISE_CLIENT_TIMEOUT,
+                                       params={
+                                           'username': username,
+                                       })
+            response.raise_for_status()
+            response_json = response.json()
+        except (ConnectionError, HTTPError, Timeout) as exc:
+            logger.exception(f'An error occurred while requesting enterprise customer data'
+                             f' from  {self.enterprise_customer_info_endpoint}: {exc}')
+            return False
+
+        response_data = response_json.get('count', 0)
+        is_enterprise_user = response_data > 0
+
+        return is_enterprise_user

--- a/commerce_coordinator/apps/enterprise_learner/tests/test_enterprise_client.py
+++ b/commerce_coordinator/apps/enterprise_learner/tests/test_enterprise_client.py
@@ -1,0 +1,108 @@
+"""
+Tests for Enterprise client.
+"""
+
+import ddt
+import mock
+from django.conf import settings
+from django.test import TestCase, override_settings
+from requests import Response
+
+from commerce_coordinator.apps.enterprise_learner.enterprise_client import EnterpriseApiClient
+
+
+@override_settings(
+    BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL='https://testserver.com/auth'
+)
+@ddt.ddt
+class TestEnterpriseApiClient(TestCase):
+    """
+    Test Discovery Api client.
+    """
+
+    @ddt.data(
+        {'username': "edx_enterprise",
+         'response_data': {
+             "count": 1,
+             "num_pages": 1,
+             "current_page": 1,
+             "next": None,
+             "start": 0,
+             "previous": None,
+             "results": [
+                 {
+                     "enterprise_customer": {
+                         "uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                         "name": "edx",
+                         "active": True
+                     },
+                     "user_id": 1,
+                     "user": {
+                         "username": "edx",
+                         "first_name": "",
+                         "last_name": "",
+                         "email": "edx@example.com"
+                     },
+                     "data_sharing_consent_records": [
+                         {
+                             "username": "edx",
+                             "enterprise_customer_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                         }
+                     ]
+                 }
+             ]
+         }
+         },
+        {
+            'username': "edx_non_enterprise",
+            'response_data': {
+                "count": 0,
+                "num_pages": 0,
+                "current_page": 1,
+                "next": None,
+                "start": 0,
+                "previous": None,
+                "results": []
+            }
+        }
+    )
+    @ddt.unpack
+    def test_check_user_is_enterprise_customer(self, username, response_data):
+        """Successfully checks if user is enterprise"""
+        with mock.patch('requests.Response.json') as mock_json:
+            with mock.patch('commerce_coordinator.apps.core.clients.OAuthAPIClient') as mock_oauth_client:
+                mock_json.return_value = response_data
+                mock_oauth_client.return_value.get.return_value = Response()
+                mock_oauth_client.return_value.get.return_value.status_code = 200
+
+                client = EnterpriseApiClient()
+                is_enterprise_customer = client.check_user_is_enterprise_customer(username)
+                assert is_enterprise_customer == (response_data['count'] > 0)
+
+                expected_url = (
+                    'http://enterprise.example.com/'
+                    'enterprise/api/v1/'
+                    'enterprise-learner'
+                )
+
+                # Check that the API endpoint was only called once.
+                mock_oauth_client.return_value.get.assert_called_once_with(
+                    expected_url,
+                    timeout=settings.ENTERPRISE_CLIENT_TIMEOUT,
+                    params={'username': username}
+                )
+
+    @ddt.data(
+        {
+            'username': 'edx_non_enterprise',
+        }
+    )
+    @ddt.unpack
+    def test_check_user_is_enterprise_customer_failure(self, username):
+        with mock.patch('commerce_coordinator.apps.core.clients.OAuthAPIClient') as mock_oauth_client:
+            mock_oauth_client.return_value.get.return_value = Response()
+            mock_oauth_client.return_value.get.return_value.status_code = 400
+            client = EnterpriseApiClient()
+            mock_response = client.check_user_is_enterprise_customer(username)
+            mock_response_msg = 'Not enterprise user'
+            self.assertFalse(mock_response, mock_response_msg)

--- a/commerce_coordinator/apps/enterprise_learner/tests/test_utils.py
+++ b/commerce_coordinator/apps/enterprise_learner/tests/test_utils.py
@@ -1,0 +1,45 @@
+"""Enterprise Learner Utils Test"""
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from mock import patch
+
+from commerce_coordinator.apps.enterprise_learner.utils import is_user_enterprise_learner
+
+User = get_user_model()
+
+
+class TestEnterpriseLearnerUtils(TestCase):
+    """
+    Test class for utils
+    """
+    url = reverse('lms:payment_page_redirect')
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username='test', email='test@example.com', password='secret'
+        )
+
+    @patch(
+        'commerce_coordinator.apps.enterprise_learner.enterprise_client'
+        '.EnterpriseApiClient.check_user_is_enterprise_customer'
+        )
+    def test_check_user_enterprise(self, mock_enterprise_user):
+        request = self.factory.get(self.url)
+        request.user = self.user
+        mock_enterprise_user.return_value = True
+        enterprise_user = is_user_enterprise_learner(request)
+        self.assertTrue(enterprise_user, f'{request.user} is an enterprise user')
+
+    @patch(
+        'commerce_coordinator.apps.enterprise_learner.enterprise_client'
+        '.EnterpriseApiClient.check_user_is_enterprise_customer'
+        )
+    def test_check_user_non_enterprise(self, mock_enterprise_user):
+        request = self.factory.get(self.url)
+        request.user = self.user
+        mock_enterprise_user.return_value = False
+        enterprise_user = is_user_enterprise_learner(request)
+        self.assertFalse(enterprise_user, f'{request.user} is not an enterprise user')

--- a/commerce_coordinator/apps/enterprise_learner/utils.py
+++ b/commerce_coordinator/apps/enterprise_learner/utils.py
@@ -1,0 +1,12 @@
+from commerce_coordinator.apps.enterprise_learner.enterprise_client import EnterpriseApiClient
+
+
+def is_user_enterprise_learner(request):
+    """
+    Check if user is enterprise learner
+    :param request: request object
+    :return: Boolean whether user is enterprise learner or not
+    """
+    if (EnterpriseApiClient().check_user_is_enterprise_customer(request.user.username)):
+        return True
+    return False

--- a/commerce_coordinator/apps/rollout/pipeline.py
+++ b/commerce_coordinator/apps/rollout/pipeline.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import APIException
 
 from commerce_coordinator.apps.commercetools.clients import CommercetoolsAPIClient
 from commerce_coordinator.apps.commercetools_frontend.constants import COMMERCETOOLS_FRONTEND
+from commerce_coordinator.apps.enterprise_learner.utils import is_user_enterprise_learner
 from commerce_coordinator.apps.frontend_app_payment.constants import FRONTEND_APP_PAYMENT_CHECKOUT
 from commerce_coordinator.apps.rollout.waffle import is_redirect_to_commercetools_enabled_for_user
 
@@ -47,7 +48,7 @@ class GetActiveOrderManagementSystem(PipelineStep):
 
         if is_redirect_to_commercetools_enabled_for_user(request) and commercetools_available_course:
             active_order_management_system = COMMERCETOOLS_FRONTEND
-        elif sku:
+        elif sku and is_user_enterprise_learner(request):
             active_order_management_system = FRONTEND_APP_PAYMENT_CHECKOUT
         else:
             logger.exception(f'An error occurred while determining the active order management system.'

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -60,6 +60,15 @@ PROJECT_APPS = (
 INSTALLED_APPS += THIRD_PARTY_APPS
 INSTALLED_APPS += PROJECT_APPS
 
+# CACHE CONFIGURATION
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}
+# END CACHE CONFIGURATION
+
 MIDDLEWARE = (
     # Resets RequestCache utility for added safety.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
@@ -90,16 +99,6 @@ MIDDLEWARE = (
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 )
 
-# Cache Configuration
-CACHES = {
-    'default': {
-        'VERSION': '1',
-        'KEY_FUNCTION': 'commerce_coordinator.apps.core.memcache.safe_key',
-        'LOCATION': ['localhost:11211'],
-        'KEY_PREFIX': 'default',
-        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-    },
-}
 DEFAULT_TIMEOUT = 30 * 60  # Value is in seconds
 # End Cache Configuration
 
@@ -349,6 +348,15 @@ FULFILLMENT_TIMEOUT = 7
 ECOMMERCE_URL = 'https://ecommerce_url/'
 ECOMMERCE_ADD_TO_BASKET_API_PATH = '/basket/add/'
 TITAN_URL = 'replace-me'
+
+# Enterprise URL
+ENTERPRISE_URL = 'SET-ME-PLEASE'
+
+# Timeout for enterprise client
+ENTERPRISE_CLIENT_TIMEOUT = os.environ.get('ENTERPRISE_CLIENT_TIMEOUT', 15)
+ENTERPRISE_USER_CACHE_TIMEOUT = 600  # Value is in seconds
+
+SYSTEM_ENTERPRISE_LEARNER_ROLE = 'enterprise_learner'
 
 # Checkout view urls
 COMMERCETOOLS_FRONTEND_URL = 'https://commerce_tools_frontend_url/'

--- a/commerce_coordinator/settings/devstack.py
+++ b/commerce_coordinator/settings/devstack.py
@@ -66,6 +66,7 @@ CELERY_BROKER_URL = "redis://:password@edx.devstack.redis:6379/0"
 # Application URLs in devstack.
 ECOMMERCE_URL = "http://edx.devstack.ecommerce:18130"
 TITAN_URL = os.environ.get('TITAN_URL_ROOT', 'http://titan_titan-app_1:3000')
+ENTERPRISE_URL = 'http://edx.devstack.lms:18000'
 
 # Set legacy credentials to access edX services.
 EDX_API_KEY = 'PUT_YOUR_API_KEY_HERE'  # This is the actual API key in devstack.

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -12,15 +12,6 @@ INSTALLED_APPS += (
     'commerce_coordinator.apps.demo_lms.apps.DemoLmsConfig',
 )
 
-# CACHE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
-# END CACHE CONFIGURATION
-
 # CORS CONFIGURATION
 CORS_ORIGIN_WHITELIST = [
     'http://localhost:1996',  # frontend-app-ecommerce

--- a/commerce_coordinator/settings/test.py
+++ b/commerce_coordinator/settings/test.py
@@ -49,3 +49,6 @@ COMMERCETOOLS_CONFIG = {
     'authUrl': "https://localhost/oauth/token",
     'projectKey': "test",
 }
+
+# Test enterprise url
+ENTERPRISE_URL = 'http://enterprise.example.com'


### PR DESCRIPTION
**Description**: Configured `enterprise_client` that checks whether a user is enterprise or not. Enterprise users will then be redirected to legacy.

**JIRA**: [SONIC-124](https://2u-internal.atlassian.net/browse/SONIC-124) 
