### PR TITLE
feat: Modified CT order history implementation

### DIFF
--- a/commerce_coordinator/apps/commercetools/catalog_info/utils.py
+++ b/commerce_coordinator/apps/commercetools/catalog_info/utils.py
@@ -49,6 +49,9 @@ def un_ls(string_dict: LSLike, preferred_lang: Optional[str] = None):
         format, as described in BCP 47.
         string_dict (dict|CTLocalizedString): a LocalizedString like value
     """
+    if string_dict is None:
+        return None
+
     preferred_langs = [*LS_OUT_PREFERENCES]
 
     if preferred_lang:

--- a/commerce_coordinator/apps/commercetools/clients.py
+++ b/commerce_coordinator/apps/commercetools/clients.py
@@ -170,7 +170,8 @@ class CommercetoolsAPIClient:
             return results.results[0]
 
     def get_orders(self, customer: CTCustomer, offset=0,
-                   limit=ORDER_HISTORY_PER_SYSTEM_REQ_LIMIT) -> PaginatedResult[CTOrder]:
+                   limit=ORDER_HISTORY_PER_SYSTEM_REQ_LIMIT,
+                   order_state="Complete") -> PaginatedResult[CTOrder]:
 
         """
         Call commercetools API overview endpoint for data about historical orders.
@@ -186,8 +187,9 @@ class CommercetoolsAPIClient:
         See sample response in tests.py
 
         """
+        order_where_clause = f"orderState=\"{order_state}\""
         values = self.base_client.orders.query(
-            where="customerId=:cid",
+            where=["customerId=:cid", order_where_clause],
             predicate_var={'cid': customer.id},
             sort=["completedAt desc", "lastModifiedAt desc"],
             limit=limit,

--- a/commerce_coordinator/apps/commercetools/tests/catalog_info/test_utils.py
+++ b/commerce_coordinator/apps/commercetools/tests/catalog_info/test_utils.py
@@ -72,6 +72,10 @@ class LocalizedStringsTests(TestCase):
         result = un_ls(ls_struct, pref)
         self.assertEqual(result, expected)
 
+    def test_un_ls_with_none_string_dict(self):
+        result = un_ls(None)
+        self.assertIsNone(result)
+
     @ddt.data(
         ({Languages.ENGLISH: "abc"}, {Languages.ENGLISH: "abc"}, True),
         ({Languages.US_ENGLISH: "abc"}, {Languages.ENGLISH: "xyz"}, False),


### PR DESCRIPTION
Description
Verified the current implementation to retrieve the customers order history from Commercetools is functioning correctly and have modified the implementation to only fetch completed orders.

JIRA
https://2u-internal.atlassian.net/browse/SONIC-128
