### PR TITLE
Revert "fix: restrict commercetools /fulfill view to staff users"

### DIFF
--- a/commerce_coordinator/apps/commercetools/tests/test_views.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_views.py
@@ -174,18 +174,6 @@ class OrderFulfillViewTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    def test_unauthorized_user(self, mock_customer, mock_order, mock_signal):
-        """Check unauthorized user is forbidden."""
-
-        # Login
-        self.client.login(username=self.test_user_username, password=self.test_password)
-
-        # Send request
-        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_SANCTIONED_MESSAGE, format='json')
-
-        # Check 403 Forbidden
-        self.assertEqual(response.status_code, 403)
-
 
 @ddt.ddt
 class OrderSanctionedViewTests(APITestCase):
@@ -320,15 +308,3 @@ class OrderSanctionedViewTests(APITestCase):
 
         # Check 200 OK
         self.assertEqual(response.status_code, 200)
-
-    def test_unauthorized_user(self):
-        """Check unauthorized user is forbidden."""
-
-        # Login
-        self.client.login(username=self.test_user_username, password=self.test_password)
-
-        # Send request
-        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_SANCTIONED_MESSAGE, format='json')
-
-        # Check 403 Forbidden
-        self.assertEqual(response.status_code, 403)

--- a/commerce_coordinator/apps/commercetools/tests/test_views.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_views.py
@@ -181,7 +181,7 @@ class OrderFulfillViewTests(APITestCase):
         self.client.login(username=self.test_user_username, password=self.test_password)
 
         # Send request
-        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE, format='json')
+        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_SANCTIONED_MESSAGE, format='json')
 
         # Check 403 Forbidden
         self.assertEqual(response.status_code, 403)

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -36,8 +36,6 @@ SOURCE_SYSTEM = 'commercetools'
 class OrderFulfillView(APIView):
     """Order Fulfillment View"""
 
-    permission_classes = [IsAdminUser]
-
     def post(self, request):
         """Receive a message from commerce tools forwarded by aws event bridge"""
         input_data = {


### PR DESCRIPTION
## Description
Reverts edx/commerce-coordinator#166.

Adding authentication on this endpoint did not work because AWS EventBridge, which communicates with this endpoint, is authenticating by sending a header like `Authorization: Bearer <token>`.

Unfortunately, the edx-drf-extensions' [JwtAuthentication](https://github.com/openedx/edx-drf-extensions/blob/master/edx_rest_framework_extensions/auth/jwt/authentication.py) class is default-configured to recognize `Authorization: JWT <token>`, as that is how the MFEs are set up.

We can try to change [JWT_AUTH_HEADER_PREFIX](https://styria-digital.github.io/django-rest-framework-jwt/#jwt_auth_header_prefix), but will revert first so other work can continue to be performed with fulfillment in the pipeline.

I also tried to use edx-drf-extensions' [BearerAuthentication](https://github.com/openedx/edx-drf-extensions/blob/master/edx_rest_framework_extensions/auth/bearer/authentication.py) in https://github.com/edx/commerce-coordinator/commit/f0052ecb5b2570850be0d7cb5e9cf2a154a77349. However, besides being intended for deprecation, it also requires a `OAUTH2_USER_INFO_URL` which provides user information given a Bearer token, which we do not have available in LMS.

## Additional Information

* Jira: [SONIC-268](https://2u-internal.atlassian.net/browse/SONIC-268)