### PR TITLE
feat: Transition LineItemState on fulfillment

### DIFF
--- a/commerce_coordinator/apps/commercetools/catalog_info/constants.py
+++ b/commerce_coordinator/apps/commercetools/catalog_info/constants.py
@@ -3,6 +3,10 @@ class TwoUKeys:
     CROSS_SYS_USER_INFO_TYPE = '2u-user_information'
 
     SDN_SANCTIONED_ORDER_STATE = '2u-sdn-order-state'
+    PENDING_FULFILMENT_STATE = '2u-fulfillment-pending-state'
+    PROCESSING_FULFILMENT_STATE = '2u-fulfillment-processing-state'
+    SUCCESS_FULFILMENT_STATE = '2u-fulfillment-success-state'
+    FAILURE_FULFILMENT_STATE = '2u-fulfillment-failure-state'
 
 
 class EdXFieldNames:

--- a/commerce_coordinator/apps/commercetools/catalog_info/foundational_types.py
+++ b/commerce_coordinator/apps/commercetools/catalog_info/foundational_types.py
@@ -21,6 +21,40 @@ class TwoUCustomStates:
         description=ls({'en': 'This order has been sanctioned for an SDN hit'})
     )
 
+    PENDING_FULFILLMENT_STATE = StateDraft(
+        key=TwoUKeys.PENDING_FULFILMENT_STATE,
+        type=StateTypeEnum.LINE_ITEM_STATE,
+        name=ls({'en': 'Fulfillment Pending'}),
+        description=ls({'en': 'This order line item is pending fulfilment'}),
+        initial=False,
+        transitions=[]
+    )
+
+    PROCESSING_FULFILLMENT_STATE = StateDraft(
+        key=TwoUKeys.PROCESSING_FULFILMENT_STATE,
+        type=StateTypeEnum.LINE_ITEM_STATE,
+        name=ls({'en': 'Fulfillment Processing'}),
+        description=ls({'en': 'This order line item is processing fulfilment'}),
+        initial=False,
+        transitions=[]
+    )
+
+    SUCCESS_FULFILLMENT_STATE = StateDraft(
+        key=TwoUKeys.SUCCESS_FULFILMENT_STATE,
+        type=StateTypeEnum.LINE_ITEM_STATE,
+        name=ls({'en': 'Fulfillment Success'}),
+        description=ls({'en': 'This order line item has successfully been fulfilled'}),
+        transitions=[]
+    )
+
+    FAILED_FULFILLMENT_STATE = StateDraft(
+        key=TwoUKeys.FAILURE_FULFILMENT_STATE,
+        type=StateTypeEnum.LINE_ITEM_STATE,
+        name=ls({'en': 'Fulfillment Failure'}),
+        description=ls({'en': 'This order line item was unsuccessfully fulfilled'}),
+        transitions=[]
+    )
+
 
 class TwoUCustomTypes:
     """Global 2U Custom Type Definitions in Commercetools"""

--- a/commerce_coordinator/apps/commercetools/management/commands/provision_order_states.py
+++ b/commerce_coordinator/apps/commercetools/management/commands/provision_order_states.py
@@ -39,7 +39,6 @@ class Command(CommercetoolsAPIClientCommand):
 
             print(json.dumps(state.serialize()))
 
-
         # Updating built-in 'Initial' line item state transition to 'Fulfiment Pending' state
         initial_state = self.ct_api_client.base_client.states.get_by_key('Initial')
         pending_transition = types.StateResourceIdentifier(key=TwoUCustomStates.PENDING_FULFILLMENT_STATE.key)
@@ -56,11 +55,13 @@ class Command(CommercetoolsAPIClientCommand):
         except CommercetoolsError as _:
             pass
 
-
-        # Updating the transitions of the fulfillment states after they have been created
+        # Updating the line item state transitions of the fulfillment states after they have been created
         for state_draft_ref in order_states:
             state = None
-            if state_draft_ref != TwoUCustomStates.SANCTIONED_ORDER_STATE and state_draft_ref != TwoUCustomStates.SUCCESS_FULFILLMENT_STATE:
+            if (
+                state_draft_ref != TwoUCustomStates.SANCTIONED_ORDER_STATE and
+                state_draft_ref != TwoUCustomStates.SUCCESS_FULFILLMENT_STATE
+            ):
                 try:
                     state = self.ct_api_client.base_client.states.get_by_key(state_draft_ref.key)
                 except CommercetoolsError as _:
@@ -86,7 +87,6 @@ class Command(CommercetoolsAPIClientCommand):
                             types.StateResourceIdentifier(key=TwoUCustomStates.SUCCESS_FULFILLMENT_STATE.key)
                         ]
 
-
                     if all(transition in current_transitions for transition in new_transitions):
                         print(f'The {state.name} state already has the expected transitions.')
                     else:
@@ -101,4 +101,3 @@ class Command(CommercetoolsAPIClientCommand):
                             print(json.dumps(state.serialize()))
                         except CommercetoolsError as _:
                             pass
-

--- a/commerce_coordinator/apps/commercetools/management/commands/provision_order_states.py
+++ b/commerce_coordinator/apps/commercetools/management/commands/provision_order_states.py
@@ -29,7 +29,7 @@ class Command(CommercetoolsAPIClientCommand):
             try:
                 state = self.ct_api_client.base_client.states.get_by_key(state_draft.key)
             except CommercetoolsError as _:  # pragma: no cover
-                # commercetools.exceptions.CommercetoolsError: The Resource with key 'edx-user_information' was not found.
+                # commercetools.exceptions.CommercetoolsError: The Resource with key '' was not found.
                 pass
             except requests.exceptions.HTTPError as _:  # The test framework doesn't wrap to CommercetoolsError
                 pass
@@ -41,7 +41,7 @@ class Command(CommercetoolsAPIClientCommand):
 
 
         # Updating built-in 'Initial' line item state transition to 'Fulfiment Pending' state
-        initial_state = self.ct_api_client.base_client.states.get_by_key("Initial")
+        initial_state = self.ct_api_client.base_client.states.get_by_key('Initial')
         pending_transition = types.StateResourceIdentifier(key=TwoUCustomStates.PENDING_FULFILLMENT_STATE.key)
         try:
             updated_initial_state = self.ct_api_client.base_client.states.update_by_id(
@@ -51,10 +51,9 @@ class Command(CommercetoolsAPIClientCommand):
                     types.StateSetTransitionsAction(transitions=[pending_transition])
                 ]
             )
-            print("Initial state updated successfully.")
+            print('Initial state updated successfully.')
             print(json.dumps(updated_initial_state.serialize()))
         except CommercetoolsError as _:
-            # Handle the error appropriately
             pass
 
 
@@ -65,7 +64,7 @@ class Command(CommercetoolsAPIClientCommand):
                 try:
                     state = self.ct_api_client.base_client.states.get_by_key(state_draft_ref.key)
                 except CommercetoolsError as _:
-                    # Handle the error appropriately
+                    # commercetools.exceptions.CommercetoolsError: The Resource with key '' was not found.
                     pass
 
                 if state:
@@ -86,8 +85,9 @@ class Command(CommercetoolsAPIClientCommand):
                             types.StateResourceIdentifier(key=TwoUCustomStates.PENDING_FULFILLMENT_STATE.key)
                         ]
 
+
                     if all(transition in current_transitions for transition in new_transitions):
-                        print("The state already has the expected transitions.")
+                        print(f'The {state.name} state already has the expected transitions.')
                     else:
                         try:
                             self.ct_api_client.base_client.states.update_by_id(
@@ -95,10 +95,9 @@ class Command(CommercetoolsAPIClientCommand):
                                 version=state.version,
                                 actions=[
                                     types.StateSetTransitionsAction(transitions=new_transitions)
-                                ]
+                                ],
                             )
                             print(json.dumps(state.serialize()))
-                        except CommercetoolsError as e:
-                            # Handle the error appropriately
+                        except CommercetoolsError as _:
                             pass
 

--- a/commerce_coordinator/apps/commercetools/management/commands/provision_order_states.py
+++ b/commerce_coordinator/apps/commercetools/management/commands/provision_order_states.py
@@ -1,10 +1,9 @@
 import json
 
 import requests
-from commercetools import CommercetoolsError
+from commercetools import CommercetoolsError, types
 from django.core.management.base import no_translations
 
-from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
 from commerce_coordinator.apps.commercetools.catalog_info.foundational_types import TwoUCustomStates
 from commerce_coordinator.apps.commercetools.management.commands._ct_api_client_command import (
     CommercetoolsAPIClientCommand
@@ -12,22 +11,94 @@ from commerce_coordinator.apps.commercetools.management.commands._ct_api_client_
 
 
 class Command(CommercetoolsAPIClientCommand):
-    help = "Add Workflow States"
+    help = "Add Workflow and LineItem States"
 
     @no_translations
     def handle(self, *args, **options):
 
-        state = None
+        order_states = [
+            TwoUCustomStates.SANCTIONED_ORDER_STATE,
+            TwoUCustomStates.PENDING_FULFILLMENT_STATE,
+            TwoUCustomStates.PROCESSING_FULFILLMENT_STATE,
+            TwoUCustomStates.SUCCESS_FULFILLMENT_STATE,
+            TwoUCustomStates.FAILED_FULFILLMENT_STATE
+        ]
 
+        for state_draft in order_states:
+            state = None
+            try:
+                state = self.ct_api_client.base_client.states.get_by_key(state_draft.key)
+            except CommercetoolsError as _:  # pragma: no cover
+                # commercetools.exceptions.CommercetoolsError: The Resource with key 'edx-user_information' was not found.
+                pass
+            except requests.exceptions.HTTPError as _:  # The test framework doesn't wrap to CommercetoolsError
+                pass
+
+            if not state:
+                state = self.ct_api_client.base_client.states.create(state_draft)
+
+            print(json.dumps(state.serialize()))
+
+
+        # Updating built-in 'Initial' line item state transition to 'Fulfiment Pending' state
+        initial_state = self.ct_api_client.base_client.states.get_by_key("Initial")
+        pending_transition = types.StateResourceIdentifier(key=TwoUCustomStates.PENDING_FULFILLMENT_STATE.key)
         try:
-            state = self.ct_api_client.base_client.states.get_by_key(TwoUKeys.SDN_SANCTIONED_ORDER_STATE)
-        except CommercetoolsError as _:  # pragma: no cover
-            # commercetools.exceptions.CommercetoolsError: The Resource with key 'edx-user_information' was not found.
-            pass
-        except requests.exceptions.HTTPError as _:  # The test framework doesn't wrap to CommercetoolsError
+            updated_initial_state = self.ct_api_client.base_client.states.update_by_id(
+                id=initial_state.id,
+                version=initial_state.version,
+                actions=[
+                    types.StateSetTransitionsAction(transitions=[pending_transition])
+                ]
+            )
+            print("Initial state updated successfully.")
+            print(json.dumps(updated_initial_state.serialize()))
+        except CommercetoolsError as _:
+            # Handle the error appropriately
             pass
 
-        if not state:
-            state = self.ct_api_client.base_client.states.create(TwoUCustomStates.SANCTIONED_ORDER_STATE)
 
-        print(json.dumps(state.serialize()))
+        # Updating the transitions of the fulfillment states after they have been created
+        for state_draft_ref in order_states:
+            state = None
+            if state_draft_ref != TwoUCustomStates.SANCTIONED_ORDER_STATE and state_draft_ref != TwoUCustomStates.SUCCESS_FULFILLMENT_STATE:
+                try:
+                    state = self.ct_api_client.base_client.states.get_by_key(state_draft_ref.key)
+                except CommercetoolsError as _:
+                    # Handle the error appropriately
+                    pass
+
+                if state:
+                    new_transitions = None
+                    current_transitions = [transition.id for transition in state.transitions]
+
+                    if state_draft_ref == TwoUCustomStates.PENDING_FULFILLMENT_STATE:
+                        new_transitions = [
+                            types.StateResourceIdentifier(key=TwoUCustomStates.PROCESSING_FULFILLMENT_STATE.key)
+                        ]
+                    elif state_draft_ref == TwoUCustomStates.PROCESSING_FULFILLMENT_STATE:
+                        new_transitions = [
+                            types.StateResourceIdentifier(key=TwoUCustomStates.SUCCESS_FULFILLMENT_STATE.key),
+                            types.StateResourceIdentifier(key=TwoUCustomStates.FAILED_FULFILLMENT_STATE.key)
+                        ]
+                    elif state_draft_ref == TwoUCustomStates.FAILED_FULFILLMENT_STATE:
+                        new_transitions = [
+                            types.StateResourceIdentifier(key=TwoUCustomStates.PENDING_FULFILLMENT_STATE.key)
+                        ]
+
+                    if all(transition in current_transitions for transition in new_transitions):
+                        print("The state already has the expected transitions.")
+                    else:
+                        try:
+                            self.ct_api_client.base_client.states.update_by_id(
+                                id=state.id,
+                                version=state.version,
+                                actions=[
+                                    types.StateSetTransitionsAction(transitions=new_transitions)
+                                ]
+                            )
+                            print(json.dumps(state.serialize()))
+                        except CommercetoolsError as e:
+                            # Handle the error appropriately
+                            pass
+

--- a/commerce_coordinator/apps/commercetools/management/commands/provision_order_states.py
+++ b/commerce_coordinator/apps/commercetools/management/commands/provision_order_states.py
@@ -82,7 +82,8 @@ class Command(CommercetoolsAPIClientCommand):
                         ]
                     elif state_draft_ref == TwoUCustomStates.FAILED_FULFILLMENT_STATE:
                         new_transitions = [
-                            types.StateResourceIdentifier(key=TwoUCustomStates.PENDING_FULFILLMENT_STATE.key)
+                            types.StateResourceIdentifier(key=TwoUCustomStates.PENDING_FULFILLMENT_STATE.key),
+                            types.StateResourceIdentifier(key=TwoUCustomStates.SUCCESS_FULFILLMENT_STATE.key)
                         ]
 
 

--- a/commerce_coordinator/apps/commercetools/serializers.py
+++ b/commerce_coordinator/apps/commercetools/serializers.py
@@ -40,9 +40,13 @@ class OrderFulfillViewInputSerializer(CoordinatorSerializer):
     course_mode = serializers.CharField(allow_null=False)
     date_placed = serializers.CharField(allow_null=False)
     email_opt_in = serializers.BooleanField(allow_null=False)
+    item_id = serializers.CharField(allow_null=False)
+    item_quantity = serializers.IntegerField(allow_null=False)
     order_number = serializers.CharField(allow_null=False)
+    order_version = serializers.CharField(allow_null=False)
     provider_id = serializers.CharField(allow_null=True)
     source_system = serializers.CharField(allow_null=False)
+    state_ids = serializers.ListField(allow_null=False)
     edx_lms_user_id = serializers.IntegerField(allow_null=False)
 
 

--- a/commerce_coordinator/apps/commercetools/serializers.py
+++ b/commerce_coordinator/apps/commercetools/serializers.py
@@ -31,6 +31,36 @@ class OrderMessageInputSerializer(CoordinatorSerializer):
         representation = representation.pop('detail')
         return representation
 
+class OrderLineItemMessageDetailSerializer(CoordinatorSerializer):
+    """
+    Serializer for CommerceTools message 'detail'
+    """
+    resourceUserProvidedIdentifiers = serializers.DictField(child=serializers.CharField())
+    fromState = serializers.DictField(child=serializers.CharField())
+    toState = serializers.DictField(child=serializers.CharField())
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        order_number = representation['resourceUserProvidedIdentifiers'].get('orderNumber')
+        if order_number:
+            representation['order_number'] = order_number
+        representation.pop('resourceUserProvidedIdentifiers')
+        representation['from_state'] = representation.pop('fromState')
+        representation['to_state'] = representation.pop('toState')
+        return representation
+
+
+class OrderLineItemMessageInputSerializer(CoordinatorSerializer):
+    """
+    Serializer for commercetools message input
+    """
+    detail = OrderLineItemMessageDetailSerializer(allow_null=False)
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        representation = representation.pop('detail')
+        return representation
+
 
 class OrderFulfillViewInputSerializer(CoordinatorSerializer):
     """

--- a/commerce_coordinator/apps/commercetools/serializers.py
+++ b/commerce_coordinator/apps/commercetools/serializers.py
@@ -31,6 +31,7 @@ class OrderMessageInputSerializer(CoordinatorSerializer):
         representation = representation.pop('detail')
         return representation
 
+
 class OrderLineItemMessageDetailSerializer(CoordinatorSerializer):
     """
     Serializer for CommerceTools message 'detail'
@@ -41,7 +42,6 @@ class OrderLineItemMessageDetailSerializer(CoordinatorSerializer):
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
-        # 'resource' attribute in message holds reference to order id attached to line item
         order_id = representation['resource'].get('id')
         if order_id:
             representation['order_id'] = order_id

--- a/commerce_coordinator/apps/commercetools/serializers.py
+++ b/commerce_coordinator/apps/commercetools/serializers.py
@@ -35,16 +35,17 @@ class OrderLineItemMessageDetailSerializer(CoordinatorSerializer):
     """
     Serializer for CommerceTools message 'detail'
     """
-    resourceUserProvidedIdentifiers = serializers.DictField(child=serializers.CharField())
+    resource = serializers.DictField(child=serializers.CharField())
     fromState = serializers.DictField(child=serializers.CharField())
     toState = serializers.DictField(child=serializers.CharField())
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
-        order_number = representation['resourceUserProvidedIdentifiers'].get('orderNumber')
-        if order_number:
-            representation['order_number'] = order_number
-        representation.pop('resourceUserProvidedIdentifiers')
+        # 'resource' attribute in message holds reference to order id attached to line item
+        order_id = representation['resource'].get('id')
+        if order_id:
+            representation['order_id'] = order_id
+        representation.pop('resource')
         representation['from_state'] = representation.pop('fromState')
         representation['to_state'] = representation.pop('toState')
         return representation
@@ -70,13 +71,13 @@ class OrderFulfillViewInputSerializer(CoordinatorSerializer):
     course_mode = serializers.CharField(allow_null=False)
     date_placed = serializers.CharField(allow_null=False)
     email_opt_in = serializers.BooleanField(allow_null=False)
-    item_id = serializers.CharField(allow_null=False)
+    line_item_id = serializers.CharField(allow_null=False)
     item_quantity = serializers.IntegerField(allow_null=False)
     order_number = serializers.CharField(allow_null=False)
-    order_version = serializers.CharField(allow_null=False)
+    order_version = serializers.IntegerField(allow_null=False)
     provider_id = serializers.CharField(allow_null=True)
     source_system = serializers.CharField(allow_null=False)
-    state_ids = serializers.ListField(allow_null=False)
+    line_item_state_id = serializers.CharField(allow_null=False)
     edx_lms_user_id = serializers.IntegerField(allow_null=False)
 
 

--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -1,6 +1,44 @@
 """
 commercetools signals and receivers.
 """
-from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal
+import logging
+from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
+from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_success
+
+logger = logging.getLogger(__name__)
 
 fulfill_order_placed_signal = CoordinatorSignal()
+# fulfillment_completed_signal = CoordinatorSignal()
+
+@log_receiver(logger)
+def fulfill_order_completed_send_line_item_state(**kwargs):
+    """
+    Fulfill the order placed in Titan with a Celery task to LMS to enroll a user in a single course.
+    """
+    # response_status = kwargs['response_status']  # Get the response code from kwargs
+    item_state_ids = kwargs['state_ids']
+    logger.info(f'-- ITEM STATES {item_state_ids}')
+    result = None
+    for item_state_id in item_state_ids:
+            logger.info(f'-- STATE {item_state_id}')
+            update_line_item_state_on_fulfillment_success(
+                order_id=kwargs['order_id'],
+                order_version=kwargs['order_version'],
+                item_id=kwargs['item_id'],
+                item_quantity=kwargs['item_quantity'],
+                from_state_id=item_state_id,
+            )
+    # Depending on the response code, call the appropriate method
+    # if response_status // 100 == 2:  # 2xx codes indicate success
+    #     for item_state_id in item_state_ids:
+    #             update_line_item_state_on_fulfillment_success(
+    #                 order_id=kwargs['order_id'],
+    #                 order_version=kwargs['order_version'],
+    #                 item_id=kwargs['item_id'],
+    #                 item_quantity=kwargs['item_quantity'],
+    #                 from_state_id=item_state_id,
+    #             )
+    # else:
+    #     print('In else')
+        # fulfill_order_completed_send_line_item_state_failure(**kwargs)
+    return result

--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -2,13 +2,15 @@
 Commercetools signals and receivers.
 """
 import logging
-from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
+
 from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
 from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion
+from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
 
 logger = logging.getLogger(__name__)
 
 fulfill_order_placed_signal = CoordinatorSignal()
+
 
 @log_receiver(logger)
 def fulfill_order_completed_send_line_item_state(**kwargs):
@@ -26,7 +28,7 @@ def fulfill_order_completed_send_line_item_state(**kwargs):
     result = update_line_item_state_on_fulfillment_completion(
         order_id=kwargs['order_id'],
         order_version=kwargs['order_version'],
-        item_id=kwargs['item_id'],
+        line_item_id=kwargs['line_item_id'],
         item_quantity=kwargs['item_quantity'],
         from_state_id=kwargs['line_item_state_id'],
         to_state_key=to_state_key

--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -3,42 +3,33 @@ commercetools signals and receivers.
 """
 import logging
 from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
-from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_success
+from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
+from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion
 
 logger = logging.getLogger(__name__)
 
 fulfill_order_placed_signal = CoordinatorSignal()
-# fulfillment_completed_signal = CoordinatorSignal()
 
 @log_receiver(logger)
 def fulfill_order_completed_send_line_item_state(**kwargs):
     """
     Fulfill the order placed in Titan with a Celery task to LMS to enroll a user in a single course.
     """
-    # response_status = kwargs['response_status']  # Get the response code from kwargs
+
+    is_fulfilled = kwargs['is_fulfilled']
     item_state_ids = kwargs['state_ids']
-    logger.info(f'-- ITEM STATES {item_state_ids}')
-    result = None
+
+    if is_fulfilled:
+        to_state_key = TwoUKeys.SUCCESS_FULFILMENT_STATE
+    else:
+        to_state_key = TwoUKeys.FAILURE_FULFILMENT_STATE
+
     for item_state_id in item_state_ids:
-            logger.info(f'-- STATE {item_state_id}')
-            update_line_item_state_on_fulfillment_success(
-                order_id=kwargs['order_id'],
-                order_version=kwargs['order_version'],
-                item_id=kwargs['item_id'],
-                item_quantity=kwargs['item_quantity'],
-                from_state_id=item_state_id,
-            )
-    # Depending on the response code, call the appropriate method
-    # if response_status // 100 == 2:  # 2xx codes indicate success
-    #     for item_state_id in item_state_ids:
-    #             update_line_item_state_on_fulfillment_success(
-    #                 order_id=kwargs['order_id'],
-    #                 order_version=kwargs['order_version'],
-    #                 item_id=kwargs['item_id'],
-    #                 item_quantity=kwargs['item_quantity'],
-    #                 from_state_id=item_state_id,
-    #             )
-    # else:
-    #     print('In else')
-        # fulfill_order_completed_send_line_item_state_failure(**kwargs)
-    return result
+                update_line_item_state_on_fulfillment_completion(
+                    order_id=kwargs['order_id'],
+                    order_version=kwargs['order_version'],
+                    item_id=kwargs['item_id'],
+                    item_quantity=kwargs['item_quantity'],
+                    from_state_id=item_state_id,
+                    to_state_key=to_state_key
+                )

--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -1,5 +1,5 @@
 """
-commercetools signals and receivers.
+Commercetools signals and receivers.
 """
 import logging
 from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
@@ -17,19 +17,19 @@ def fulfill_order_completed_send_line_item_state(**kwargs):
     """
 
     is_fulfilled = kwargs['is_fulfilled']
-    item_state_ids = kwargs['state_ids']
 
     if is_fulfilled:
         to_state_key = TwoUKeys.SUCCESS_FULFILMENT_STATE
     else:
         to_state_key = TwoUKeys.FAILURE_FULFILMENT_STATE
 
-    for item_state_id in item_state_ids:
-                update_line_item_state_on_fulfillment_completion(
-                    order_id=kwargs['order_id'],
-                    order_version=kwargs['order_version'],
-                    item_id=kwargs['item_id'],
-                    item_quantity=kwargs['item_quantity'],
-                    from_state_id=item_state_id,
-                    to_state_key=to_state_key
-                )
+    result = update_line_item_state_on_fulfillment_completion(
+        order_id=kwargs['order_id'],
+        order_version=kwargs['order_version'],
+        item_id=kwargs['item_id'],
+        item_quantity=kwargs['item_quantity'],
+        from_state_id=kwargs['line_item_state_id'],
+        to_state_key=to_state_key
+    )
+
+    return result

--- a/commerce_coordinator/apps/commercetools/sub_messages/signals_delayed.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/signals_delayed.py
@@ -19,6 +19,7 @@ def fulfill_order_placed_message_signal(**kwargs):
     """ CoordinatorSignal receiver to invoke Celery Task fulfill_order_placed_message_signal_task"""
     async_result = fulfill_order_placed_message_signal_task.delay(
         order_id=kwargs['order_id'],
+        line_item_state_id=kwargs['line_item_state_id'],
         source_system=kwargs['source_system'],
     )
     return async_result.id

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -72,7 +72,6 @@ def fulfill_order_placed_message_signal_task(
     default_params = {
         'email_opt_in': True,  # ?? Where?
         'order_number': order.id,
-        'order_version': order.version,
         'provider_id': None,
         'edx_lms_user_id': lms_user_id,
         'course_mode': 'verified',

--- a/commerce_coordinator/apps/commercetools/tasks.py
+++ b/commerce_coordinator/apps/commercetools/tasks.py
@@ -1,23 +1,33 @@
+"""
+Commercetools tasks
+"""
+
 import logging
+
 from commercetools import CommercetoolsError
+
 from .clients import CommercetoolsAPIClient
 
 logger = logging.getLogger(__name__)
 
+
 def update_line_item_state_on_fulfillment_completion(
-        order_id,
-        order_version,
-        item_id,
-        item_quantity,
-        from_state_id,
-        to_state_key
-    ):
+    order_id,
+    order_version,
+    line_item_id,
+    item_quantity,
+    from_state_id,
+    to_state_key
+):
+    """
+    Task for fulfillment completed and order line item state update via Commercetools API.
+    """
     client = CommercetoolsAPIClient()
     try:
         updated_order = client.update_line_item_transition_state_on_fulfillment(
             order_id,
             order_version,
-            item_id,
+            line_item_id,
             item_quantity,
             from_state_id,
             to_state_key

--- a/commerce_coordinator/apps/commercetools/tasks.py
+++ b/commerce_coordinator/apps/commercetools/tasks.py
@@ -1,40 +1,29 @@
 import logging
-from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
 from commercetools import CommercetoolsError
 from .clients import CommercetoolsAPIClient
 
 logger = logging.getLogger(__name__)
 
-def update_line_item_state_on_fulfillment_success(
+def update_line_item_state_on_fulfillment_completion(
         order_id,
         order_version,
         item_id,
         item_quantity,
-        from_state_id
+        from_state_id,
+        to_state_key
     ):
-    client = CommercetoolsAPIClient()  # Initialize your Commercetools client here
+    client = CommercetoolsAPIClient()
     try:
-        # Update line item state for fulfillment success
         updated_order = client.update_line_item_transition_state_on_fulfillment(
             order_id,
             order_version,
             item_id,
             item_quantity,
             from_state_id,
-            TwoUKeys.SUCCESS_FULFILMENT_STATE
+            to_state_key
         )
         return updated_order
     except CommercetoolsError as err:
-        logger.error(f"Unable to update line item [ {item_id} ] state on fulfillment success with error {err.errors} and correlation id {err.correlation_id}")
+        logger.error(f"Unable to update line item [ {item_id} ] state on fulfillment "
+                     f"success with error {err.errors} and correlation id {err.correlation_id}")
         return None
-
-# @shared_task
-# def update_line_item_state_on_fulfillment_failure(order_id, order_version, item):
-#     client = YourCommercetoolsClient()  # Initialize your Commercetools client here
-#     try:
-#         # Update line item state for fulfillment failure
-#         updated_order = client.update_line_item_transition_state_on_fulfillment(order_id, order_version, item, from_state_id, "Fulfillment Failure")
-#         return updated_order
-#     except Exception as e:
-#         logger.error(f"Error updating line item state on fulfillment failure: {str(e)}")
-#         return None

--- a/commerce_coordinator/apps/commercetools/tasks.py
+++ b/commerce_coordinator/apps/commercetools/tasks.py
@@ -1,0 +1,40 @@
+import logging
+from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
+from commercetools import CommercetoolsError
+from .clients import CommercetoolsAPIClient
+
+logger = logging.getLogger(__name__)
+
+def update_line_item_state_on_fulfillment_success(
+        order_id,
+        order_version,
+        item_id,
+        item_quantity,
+        from_state_id
+    ):
+    client = CommercetoolsAPIClient()  # Initialize your Commercetools client here
+    try:
+        # Update line item state for fulfillment success
+        updated_order = client.update_line_item_transition_state_on_fulfillment(
+            order_id,
+            order_version,
+            item_id,
+            item_quantity,
+            from_state_id,
+            TwoUKeys.SUCCESS_FULFILMENT_STATE
+        )
+        return updated_order
+    except CommercetoolsError as err:
+        logger.error(f"Unable to update line item [ {item_id} ] state on fulfillment success with error {err.errors} and correlation id {err.correlation_id}")
+        return None
+
+# @shared_task
+# def update_line_item_state_on_fulfillment_failure(order_id, order_version, item):
+#     client = YourCommercetoolsClient()  # Initialize your Commercetools client here
+#     try:
+#         # Update line item state for fulfillment failure
+#         updated_order = client.update_line_item_transition_state_on_fulfillment(order_id, order_version, item, from_state_id, "Fulfillment Failure")
+#         return updated_order
+#     except Exception as e:
+#         logger.error(f"Error updating line item state on fulfillment failure: {str(e)}")
+#         return None

--- a/commerce_coordinator/apps/commercetools/tasks.py
+++ b/commerce_coordinator/apps/commercetools/tasks.py
@@ -34,6 +34,6 @@ def update_line_item_state_on_fulfillment_completion(
         )
         return updated_order
     except CommercetoolsError as err:
-        logger.error(f"Unable to update line item [ {item_id} ] state on fulfillment "
+        logger.error(f"Unable to update line item [ {line_item_id} ] state on fulfillment "
                      f"result with error {err.errors} and correlation id {err.correlation_id}")
         return None

--- a/commerce_coordinator/apps/commercetools/tasks.py
+++ b/commerce_coordinator/apps/commercetools/tasks.py
@@ -25,5 +25,5 @@ def update_line_item_state_on_fulfillment_completion(
         return updated_order
     except CommercetoolsError as err:
         logger.error(f"Unable to update line item [ {item_id} ] state on fulfillment "
-                     f"success with error {err.errors} and correlation id {err.correlation_id}")
+                     f"result with error {err.errors} and correlation id {err.correlation_id}")
         return None

--- a/commerce_coordinator/apps/commercetools/tests/conftest.py
+++ b/commerce_coordinator/apps/commercetools/tests/conftest.py
@@ -18,6 +18,7 @@ from commercetools.platform.models import Order as CTOrder
 from commercetools.platform.models import Product as CTProduct
 from commercetools.platform.models import ProductProjectionPagedSearchResponse as CTProductProjectionPagedSearchResponse
 from commercetools.platform.models import ReturnPaymentState, ReturnShipmentState
+from commercetools.platform.models.state import State as CTLineItemState
 from commercetools.platform.models import TypeReference as CTTypeReference
 from commercetools.testing import BackendRepository
 
@@ -259,4 +260,16 @@ def gen_return_item(order_line_id: str, payment_state: ReturnPaymentState) -> CT
         last_modified_at=datetime.now(),
         created_at=datetime.now(),
         line_item_id=order_line_id
+    )
+
+def gen_line_item_state() -> CTLineItemState:
+    return CTLineItemState (
+        id= '669d3d11-5eaa-4521-b146-ccbd408ae940',
+        version=2,
+        created_at=datetime.now(),
+        last_modified_at=datetime.now(),
+        key='2u-fulfillment-pending-state',
+        type='LineItemState',
+        initial=False,
+        built_in=False,
     )

--- a/commerce_coordinator/apps/commercetools/tests/conftest.py
+++ b/commerce_coordinator/apps/commercetools/tests/conftest.py
@@ -18,8 +18,8 @@ from commercetools.platform.models import Order as CTOrder
 from commercetools.platform.models import Product as CTProduct
 from commercetools.platform.models import ProductProjectionPagedSearchResponse as CTProductProjectionPagedSearchResponse
 from commercetools.platform.models import ReturnPaymentState, ReturnShipmentState
-from commercetools.platform.models.state import State as CTLineItemState
 from commercetools.platform.models import TypeReference as CTTypeReference
+from commercetools.platform.models.state import State as CTLineItemState
 from commercetools.testing import BackendRepository
 
 from commerce_coordinator.apps.commercetools.catalog_info.constants import EdXFieldNames
@@ -262,9 +262,10 @@ def gen_return_item(order_line_id: str, payment_state: ReturnPaymentState) -> CT
         line_item_id=order_line_id
     )
 
+
 def gen_line_item_state() -> CTLineItemState:
-    return CTLineItemState (
-        id= '669d3d11-5eaa-4521-b146-ccbd408ae940',
+    return CTLineItemState(
+        id='669d3d11-5eaa-4521-b146-ccbd408ae940',
         version=2,
         created_at=datetime.now(),
         last_modified_at=datetime.now(),

--- a/commerce_coordinator/apps/commercetools/tests/constants.py
+++ b/commerce_coordinator/apps/commercetools/tests/constants.py
@@ -1,7 +1,6 @@
 '''Constants for commercetools tests'''
 from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
 from commerce_coordinator.apps.commercetools.views import OrderFulfillView
-from typing import Dict, Union
 
 EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE = {
     'version': '0',

--- a/commerce_coordinator/apps/commercetools/tests/constants.py
+++ b/commerce_coordinator/apps/commercetools/tests/constants.py
@@ -1,48 +1,60 @@
 '''Constants for commercetools tests'''
 from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
 from commerce_coordinator.apps.commercetools.views import OrderFulfillView
+from typing import Dict, Union
 
 EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE = {
     'version': '0',
-    'id': 'aaaaaaaa-8888-00ee-aaaa-aaaaaaaaaaaa',
-    'detail-type': 'OrderStateChanged',
+    'id': 'e23aa944-1937-5111-ca7f-aa651920234e',
+    'detail-type': 'LineItemStateTransition',
     'source': 'aws.partner/commercetools.com/2u-marketplace-dev-01/commerce-coordinator-eventbridge',
-    'account': '835688427423',
-    'time': '2023-11-21T13:21:11Z',
-    'region': 'us-east-2',
+    'account': '838788427423',
+    'time': '2024-03-26T11:13:26Z',
+    'region': 'us-east-1',
     'resources': [],
     'detail': {
         'notificationType': 'Message',
         'projectKey': '2u-marketplace-dev-01',
-        'id': '3cbbbbbb-ce15-4979-aaca-bb121bbbbbbb',
+        'id': '1bbcda40-a137-413a-b4a1-675f981bc5fc',
         'version': 1,
-        'sequenceNumber': 57,
+        'sequenceNumber': 5,
         'resource': {
             'typeId': 'order',
-            'id': '9e60e10b-861c-40b0-afa4-c769dcccccc1'
+            'id': '61ec1afa-1b0e-4234-ae28-f997728054fa'
         },
-        'resourceVersion': 58,
-        'type': 'OrderStateChanged',
-        'orderId': '9e60e10b-861c-40b0-afa4-c769dcccccc1',
-        'orderState': 'Complete',
-        'oldOrderState': 'Cancelled',
-        'createdAt': '2023-11-21T13:21:11.122Z',
-        'lastModifiedAt': '2023-11-21T13:21:11.122Z',
+        'resourceVersion': 5,
+        'resourceUserProvidedIdentifiers': {
+            'orderNumber': 'c1f1961f-7dac-4ec6-a0ff-364b71c082b6'
+        },
+        'type': 'LineItemStateTransition',
+        'lineItemId': '822d77c4-00a6-4fb9-909b-094ef0b8c4b9',
+        'transitionDate': '2024-03-26T11:13:26.638Z',
+        'quantity': 2,
+        'fromState': {
+            'typeId': 'state',
+            'id': '8f2e888e-9777-4557-9a7f-c649153770c2'
+        },
+        'toState': {
+            'typeId': 'state',
+            'id': '669d3d11-5eaa-4521-b146-ccbd408ae940'
+        },
+        'createdAt': '2024-03-26T11:13:26.646Z',
+        'lastModifiedAt': '2024-03-26T11:13:26.646Z',
         'createdBy': {
             'isPlatformClient': True,
             'user': {
                 'typeId': 'user',
-                'id': '5daf67fd-15a6-4d77-9149-01413dddddd3'
-            },
+                'id': 'e4713035-68c7-457d-882b-61615caefae2'
+            }
         },
         'lastModifiedBy': {
             'isPlatformClient': True,
             'user': {
                 'typeId': 'user',
-                'id': '5daf67fd-15a6-4d77-9149-01413dddddd3'
-            },
-        },
-    },
+                'id': 'e4713035-68c7-457d-882b-61615caefae2'
+            }
+        }
+    }
 }
 
 EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD = {
@@ -50,11 +62,24 @@ EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD = {
     'course_id': 'course-v1:MichiganX+InjuryPreventionX+1T2021',
     'course_mode': 'verified',
     'date_placed': 'Oct 31, 2023',
-    'edx_lms_user_id': 127,
     'email_opt_in': True,
-    'order_number': 'c1f1961f-7dac-4ec6-a0ff-364b71c082b6',
+    'line_item_id': '822d77c4-00a6-4fb9-909b-094ef0b8c4b9',
+    'item_quantity': 1,
+    'order_number': '61ec1afa-1b0e-4234-ae28-f997728054fa',
+    'order_version': '7',
     'provider_id': None,
     'source_system': 'commercetools',
+    'line_item_state_id': '8f2e888e-9777-4557-9a7f-c649153770c2',
+    'edx_lms_user_id': 127,
+}
+
+EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD = {
+    'order_id': '61ec1afa-1b0e-4234-ae28-f997728054fa',
+    'order_version': 2,
+    'line_item_id': '822d77c4-00a6-4fb9-909b-094ef0b8c4b9',
+    'item_quantity': 1,
+    'from_state_id': '8f2e888e-9777-4557-9a7f-c649153770c2',
+    'to_state_key': TwoUKeys.SUCCESS_FULFILMENT_STATE
 }
 
 EXAMPLE_COMMERCETOOLS_ORDER_SANCTIONED_MESSAGE = {

--- a/commerce_coordinator/apps/commercetools/tests/mocks.py
+++ b/commerce_coordinator/apps/commercetools/tests/mocks.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from commerce_coordinator.apps.commercetools.tests.conftest import gen_customer, gen_order
+from commerce_coordinator.apps.commercetools.tests.conftest import gen_customer, gen_line_item_state, gen_order
 from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD
 
 
@@ -26,6 +26,20 @@ class CTOrderByIdMock(MagicMock):
     """
     return_value = gen_order(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD['order_number'])
 
+
+class CTLineItemStateByIdMock(MagicMock):
+    return_value = gen_line_item_state()
+
+
+class CTLineItemStateByKeyMock(MagicMock):
+    return_value = gen_line_item_state()
+
+
+def gen_updated_line_item_state_order():
+    """jsdjkasbdj"""
+    order = gen_order(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD['order_number'])
+    order.version = 8
+    return order
 
 def get_order_with_bad_state_key():
     """Modify a canned order to have a bad transition/workflow state key"""
@@ -61,3 +75,7 @@ class CTCustomerByIdMock(MagicMock):
     EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD in the shape of format_signal_results.
     """
     return_value = gen_customer("hiya@text.example", "jim_34")
+
+
+class CTUpdateLineItemState(MagicMock):
+    return_value = gen_updated_line_item_state_order()

--- a/commerce_coordinator/apps/commercetools/tests/mocks.py
+++ b/commerce_coordinator/apps/commercetools/tests/mocks.py
@@ -27,10 +27,6 @@ class CTOrderByIdMock(MagicMock):
     return_value = gen_order(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD['order_number'])
 
 
-class CTLineItemStateByIdMock(MagicMock):
-    return_value = gen_line_item_state()
-
-
 class CTLineItemStateByKeyMock(MagicMock):
     return_value = gen_line_item_state()
 
@@ -40,6 +36,7 @@ def gen_updated_line_item_state_order():
     order = gen_order(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD['order_number'])
     order.version = 8
     return order
+
 
 def get_order_with_bad_state_key():
     """Modify a canned order to have a bad transition/workflow state key"""

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_signals_delayed.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_signals_delayed.py
@@ -24,6 +24,7 @@ class FulfillOrderPlacedMessageSignalTest(CoordinatorSignalReceiverTestCase):
     """ Commercetools Fulfillment Order Placed Signal Tester"""
     mock_parameters = {
         'order_id': uuid4_str(),
+        'line_item_state_id': uuid4_str(),
         'source_system': SOURCE_SYSTEM,
     }
 

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -14,7 +14,6 @@ from commerce_coordinator.apps.commercetools.sub_messages.tasks import (
 )
 from commerce_coordinator.apps.commercetools.tests.mocks import (
     CTCustomerByIdMock,
-    CTLineItemStateByIdMock,
     CTLineItemStateByKeyMock,
     CTOrderByIdMock,
     CTUpdateLineItemState,

--- a/commerce_coordinator/apps/commercetools/tests/test_clients.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_clients.py
@@ -486,7 +486,7 @@ class ClientTests(TestCase):
         base_url = self.client_set.get_base_url_from_client()
         mock_state_by_id().return_value = gen_line_item_state()
         mock_error_response: CommercetoolsError = {
-            "message":"Could not create return for order mock_order_id",
+            "message": "Could not create return for order mock_order_id",
             "errors": [
                 {
                     "code": "ConcurrentModification",

--- a/commerce_coordinator/apps/commercetools/tests/test_clients.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_clients.py
@@ -19,12 +19,13 @@ from django.test import TestCase
 from mock import patch
 from openedx_filters.exceptions import OpenEdxFilterException
 
-from commerce_coordinator.apps.commercetools.catalog_info.constants import EdXFieldNames
+from commerce_coordinator.apps.commercetools.catalog_info.constants import EdXFieldNames, TwoUKeys
 from commerce_coordinator.apps.commercetools.catalog_info.foundational_types import TwoUCustomTypes
 from commerce_coordinator.apps.commercetools.clients import PaginatedResult
 from commerce_coordinator.apps.commercetools.tests.conftest import (
     APITestingSet,
     gen_example_customer,
+    gen_line_item_state,
     gen_order,
     gen_order_history,
     gen_return_item
@@ -442,6 +443,117 @@ class ClientTests(TestCase):
                     order_version="2",
                     return_line_item_return_id="mock_return_item_id"
                 )
+
+    @patch('commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_state_by_id')
+    def test_successful_order_line_item_state_update(self, mock_state_by_id):
+        base_url = self.client_set.get_base_url_from_client()
+
+        mock_order = gen_order("mock_order_id")
+        mock_order.version = "2"
+        mock_line_item_state = gen_line_item_state()
+        mock_line_item_state.key = TwoUKeys.PROCESSING_FULFILMENT_STATE
+        mock_order.line_items[0].state[0].state = mock_line_item_state
+
+        mock_state_by_id().return_value = mock_line_item_state
+
+        mock_response_order = gen_order("mock_order_id")
+        mock_response_order.version = 3
+        mock_response_line_item_state = gen_line_item_state()
+        mock_response_line_item_state.id = "mock_success_id"
+        mock_response_line_item_state.key = TwoUKeys.SUCCESS_FULFILMENT_STATE
+        mock_response_order.line_items[0].state[0].state = mock_response_line_item_state
+
+        with requests_mock.Mocker(real_http=True, case_sensitive=False) as mocker:
+            mocker.post(
+                f"{base_url}orders/{mock_response_order.id}",
+                json=mock_response_order.serialize(),
+                status_code=200
+            )
+
+            result = self.client_set.client.update_line_item_transition_state_on_fulfillment(
+                mock_order.id,
+                mock_order.version,
+                mock_order.line_items[0].id,
+                1,
+                mock_order.line_items[0].state[0].state.id,
+                TwoUKeys.SUCCESS_FULFILMENT_STATE
+            )
+
+            self.assertEqual(result.line_items[0].state[0].state.id, mock_response_line_item_state.id)
+
+    @patch('commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_state_by_id')
+    def test_update_line_item_state_exception(self, mock_state_by_id):
+        base_url = self.client_set.get_base_url_from_client()
+        mock_state_by_id().return_value = gen_line_item_state()
+        mock_error_response: CommercetoolsError = {
+            "message":"Could not create return for order mock_order_id",
+            "errors": [
+                {
+                    "code": "ConcurrentModification",
+                    "detailedErrorMessage": "Object [mock_order_id] has a "
+                                            "different version than expected. Expected: 2 - Actual: 1."
+                },
+            ],
+            "response": {},
+            "correlation_id": "None"
+        }
+
+        with requests_mock.Mocker(real_http=True, case_sensitive=False) as mocker:
+            mocker.post(
+                f"{base_url}orders/mock_order_id",
+                json=mock_error_response,
+                status_code=409
+            )
+
+            with patch('commerce_coordinator.apps.commercetools.clients.logging.Logger.error') as log_mock:
+                self.client_set.client.update_line_item_transition_state_on_fulfillment(
+                    "mock_order_id",
+                    1,
+                    "mock_order_line_item_id",
+                    1,
+                    "mock_order_line_item_state.id",
+                    TwoUKeys.SUCCESS_FULFILMENT_STATE
+                )
+
+                expected_message = (
+                    f"[CommercetoolsError] Unable to update LineItemState "
+                    f"of order mock_order_id with error correlation id {mock_error_response['correlation_id']} "
+                    f"and error/s: {mock_error_response['errors']}"
+                )
+
+                log_mock.assert_called_once_with(expected_message)
+
+    @patch('commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_state_by_id')
+    @patch('commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_order_by_id')
+    def test_order_line_item_in_correct_state(self, mock_order_by_id, mock_state_by_id):
+        mock_order = gen_order("mock_order_id")
+        mock_order.version = 3
+        mock_line_item_state = gen_line_item_state()
+        mock_line_item_state.key = TwoUKeys.PROCESSING_FULFILMENT_STATE
+        mock_order.line_items[0].state[0].state = mock_line_item_state
+        line_item_id = mock_order.line_items[0].id
+
+        mock_state_by_id.return_value = mock_line_item_state
+        mock_order_by_id.return_value = mock_order
+
+        with patch('commerce_coordinator.apps.commercetools.clients.logging.Logger.info') as log_mock:
+            result = self.client_set.client.update_line_item_transition_state_on_fulfillment(
+                mock_order.id,
+                mock_order.version,
+                line_item_id,
+                1,
+                mock_order.line_items[0].state[0].state.id,
+                TwoUKeys.PROCESSING_FULFILMENT_STATE
+            )
+
+            expected_message = (
+                f"The line item {line_item_id} already has the correct state {mock_line_item_state.key}. "
+                f"Not attempting to transition LineItemState"
+            )
+
+            log_mock.assert_called_once_with(expected_message)
+            self.assertEqual(result.id, mock_order.id)
+            self.assertEqual(result.version, mock_order.version)
 
 
 class PaginatedResultsTest(TestCase):

--- a/commerce_coordinator/apps/commercetools/tests/test_signals.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_signals.py
@@ -1,0 +1,51 @@
+""" Test LMS App Signals """
+
+import logging
+from unittest.mock import patch
+
+from django.test import override_settings
+from copy import copy
+
+from commerce_coordinator.apps.core.tests.utils import CoordinatorSignalReceiverTestCase
+
+# Log using module name.
+logger = logging.getLogger(__name__)
+
+
+@override_settings(
+    CC_SIGNALS={
+        'commerce_coordinator.apps.core.tests.utils.example_signal': [
+            'commerce_coordinator.apps.commercetools.signals.fulfill_order_completed_send_line_item_state',
+        ],
+    }
+)
+
+@patch('commerce_coordinator.apps.commercetools.signals.update_line_item_state_on_fulfillment_completion')
+class FulfillOrderCompletedSendLineItemStateTest(CoordinatorSignalReceiverTestCase):
+    """ LMS Fulfillment Order Placed, Line Item State Update Signal Tester"""
+    mock_parameters = {
+        'order_id': 1,
+        'order_version': 2,
+        'item_id': 3,
+        'item_quantity': 1,
+        'line_item_state_id': 4,
+    }
+
+    def test_correct_arguments_passed_fulfillment_true(self, mock_task):
+        self.mock_parameters['is_fulfilled'] = True
+        _, logs = self.fire_signal()
+        self.mock_parameters.pop('is_fulfilled')
+        task_mock_parameters = copy(self.mock_parameters)
+        task_mock_parameters['from_state_id'] = task_mock_parameters.pop('line_item_state_id')
+        logger.info('logs.output: %s', logs.output)
+        mock_task.assert_called_with(**task_mock_parameters, to_state_key='2u-fulfillment-success-state')
+
+
+    def test_correct_arguments_passed_fulfillment_false(self, mock_task):
+        self.mock_parameters['is_fulfilled'] = False
+        _, logs = self.fire_signal()
+        self.mock_parameters.pop('is_fulfilled')
+        task_mock_parameters = copy(self.mock_parameters)
+        task_mock_parameters['from_state_id'] = task_mock_parameters.pop('line_item_state_id')
+        logger.info('logs.output: %s', logs.output)
+        mock_task.assert_called_with(**task_mock_parameters, to_state_key='2u-fulfillment-failure-state')

--- a/commerce_coordinator/apps/commercetools/tests/test_signals.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_signals.py
@@ -25,7 +25,7 @@ class FulfillOrderCompletedSendLineItemStateTest(CoordinatorSignalReceiverTestCa
     mock_parameters = {
         'order_id': 1,
         'order_version': 2,
-        'item_id': 3,
+        'line_item_id': 3,
         'item_quantity': 1,
         'line_item_state_id': 4,
     }

--- a/commerce_coordinator/apps/commercetools/tests/test_signals.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_signals.py
@@ -1,10 +1,10 @@
 """ Test LMS App Signals """
 
 import logging
+from copy import copy
 from unittest.mock import patch
 
 from django.test import override_settings
-from copy import copy
 
 from commerce_coordinator.apps.core.tests.utils import CoordinatorSignalReceiverTestCase
 
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
         ],
     }
 )
-
 @patch('commerce_coordinator.apps.commercetools.signals.update_line_item_state_on_fulfillment_completion')
 class FulfillOrderCompletedSendLineItemStateTest(CoordinatorSignalReceiverTestCase):
     """ LMS Fulfillment Order Placed, Line Item State Update Signal Tester"""
@@ -39,7 +38,6 @@ class FulfillOrderCompletedSendLineItemStateTest(CoordinatorSignalReceiverTestCa
         task_mock_parameters['from_state_id'] = task_mock_parameters.pop('line_item_state_id')
         logger.info('logs.output: %s', logs.output)
         mock_task.assert_called_with(**task_mock_parameters, to_state_key='2u-fulfillment-success-state')
-
 
     def test_correct_arguments_passed_fulfillment_false(self, mock_task):
         self.mock_parameters['is_fulfilled'] = False

--- a/commerce_coordinator/apps/commercetools/tests/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_tasks.py
@@ -1,0 +1,74 @@
+"""
+Commercetools app Task Tests
+"""
+
+import logging
+from unittest.mock import patch
+from commercetools import CommercetoolsError
+
+from django.test import TestCase
+
+from commerce_coordinator.apps.core.models import User
+from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion
+from commerce_coordinator.apps.commercetools.tests.constants import (
+    EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD
+)
+
+# Log using module name.
+logger = logging.getLogger(__name__)
+
+# Define unit under test.
+# Note: if the UUT is part of the class as an ivar, it trims off arg0 as 'self' and
+#       claims too many args supplied
+uut = update_line_item_state_on_fulfillment_completion
+
+
+@patch('commerce_coordinator.apps.commercetools.tasks.CommercetoolsAPIClient')
+class UpdateLineItemStateOnFulfillmentCompletionTaskTest(TestCase):
+    """ Update Line Item State on Fulfillment Completion Task Test """
+
+    @staticmethod
+    def unpack_for_uut(values):
+        """ Unpack the dictionary in the order required for the UUT """
+        return (
+            values['order_id'],
+            values['order_version'],
+            values['line_item_id'],
+            values['item_quantity'],
+            values['from_state_id'],
+            values['to_state_key']
+        )
+
+    def setUp(self):
+        User.objects.create(username='test-user', lms_user_id=4)
+
+    def test_correct_arguments_passed(self, mock_client):
+        '''
+        Check calling uut with mock_parameters yields call to client with
+        expected_data.
+        '''
+        _ = uut(*self.unpack_for_uut(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD))
+        logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
+        mock_client().update_line_item_transition_state_on_fulfillment.assert_called_once_with(*list(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD.values()))
+
+    @patch('commerce_coordinator.apps.commercetools.tasks.logger')
+    def test_exception_handling(self, mock_logger, mock_client):
+        '''
+        Check if an error in the client results in a logged error
+        and None returned.
+        '''
+        mock_client().update_line_item_transition_state_on_fulfillment.side_effect = CommercetoolsError(
+            message="Could not update ReturnPaymentState",
+            errors="Some error message",
+            response={},
+            correlation_id="123456"
+        )
+
+        result = uut(*self.unpack_for_uut(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD))
+
+        mock_logger.error.assert_called_once_with(
+            f"Unable to update line item [ {EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD['line_item_id']} ] state on fulfillment result "
+            "with error Some error message and correlation id 123456"
+        )
+
+        assert result is None

--- a/commerce_coordinator/apps/commercetools/tests/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_tasks.py
@@ -4,15 +4,13 @@ Commercetools app Task Tests
 
 import logging
 from unittest.mock import patch
-from commercetools import CommercetoolsError
 
+from commercetools import CommercetoolsError
 from django.test import TestCase
 
-from commerce_coordinator.apps.core.models import User
 from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion
-from commerce_coordinator.apps.commercetools.tests.constants import (
-    EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD
-)
+from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD
+from commerce_coordinator.apps.core.models import User
 
 # Log using module name.
 logger = logging.getLogger(__name__)
@@ -49,7 +47,9 @@ class UpdateLineItemStateOnFulfillmentCompletionTaskTest(TestCase):
         '''
         _ = uut(*self.unpack_for_uut(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD))
         logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
-        mock_client().update_line_item_transition_state_on_fulfillment.assert_called_once_with(*list(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD.values()))
+        mock_client().update_line_item_transition_state_on_fulfillment.assert_called_once_with(
+            *list(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD.values())
+        )
 
     @patch('commerce_coordinator.apps.commercetools.tasks.logger')
     def test_exception_handling(self, mock_logger, mock_client):
@@ -67,8 +67,8 @@ class UpdateLineItemStateOnFulfillmentCompletionTaskTest(TestCase):
         result = uut(*self.unpack_for_uut(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD))
 
         mock_logger.error.assert_called_once_with(
-            f"Unable to update line item [ {EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD['line_item_id']} ] state on fulfillment result "
-            "with error Some error message and correlation id 123456"
+            f"Unable to update line item [ {EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD['line_item_id']} ] "
+            "state on fulfillment result with error Some error message and correlation id 123456"
         )
 
         assert result is None

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -2,7 +2,6 @@
 Views for the commercetools app
 """
 import logging
-import json
 
 from edx_django_utils.cache import TieredCache
 from rest_framework import status
@@ -13,7 +12,10 @@ from rest_framework.views import APIView
 
 from commerce_coordinator.apps.commercetools.authentication import JwtBearerAuthentication
 from commerce_coordinator.apps.commercetools.constants import SOURCE_SYSTEM
-from commerce_coordinator.apps.commercetools.serializers import OrderMessageInputSerializer, OrderLineItemMessageInputSerializer
+from commerce_coordinator.apps.commercetools.serializers import (
+    OrderLineItemMessageInputSerializer,
+    OrderMessageInputSerializer
+)
 from commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch import (
     fulfill_order_placed_message_signal,
     fulfill_order_returned_signal,

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -2,6 +2,7 @@
 Views for the commercetools app
 """
 import logging
+import json
 
 from edx_django_utils.cache import TieredCache
 from rest_framework import status
@@ -133,7 +134,7 @@ class OrderFulfillView(SingleInvocationAPIView):
 
         logger.debug(f'[CT-{tag}] Message received from commercetools with details: %s', input_data)
 
-        message_details = OrderMessageInputSerializer(data=input_data)
+        message_details = OrderLineItemMessageInputSerializer(data=input_data)
         message_details.is_valid(raise_exception=True)
 
         order_id = message_details.data['order_id']

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -13,7 +13,7 @@ from rest_framework.views import APIView
 
 from commerce_coordinator.apps.commercetools.authentication import JwtBearerAuthentication
 from commerce_coordinator.apps.commercetools.constants import SOURCE_SYSTEM
-from commerce_coordinator.apps.commercetools.serializers import OrderMessageInputSerializer
+from commerce_coordinator.apps.commercetools.serializers import OrderMessageInputSerializer, OrderLineItemMessageInputSerializer
 from commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch import (
     fulfill_order_placed_message_signal,
     fulfill_order_returned_signal,
@@ -138,6 +138,7 @@ class OrderFulfillView(SingleInvocationAPIView):
         message_details.is_valid(raise_exception=True)
 
         order_id = message_details.data['order_id']
+        line_item_state_id = message_details.data['to_state']['id']
 
         if self._is_running(tag, order_id):  # pragma no cover
             self.meta_should_mark_not_running = False
@@ -148,6 +149,7 @@ class OrderFulfillView(SingleInvocationAPIView):
         fulfill_order_placed_message_signal.send_robust(
             sender=self,
             order_id=order_id,
+            line_item_state_id=line_item_state_id,
             source_system=SOURCE_SYSTEM
         )
 

--- a/commerce_coordinator/apps/lms/clients.py
+++ b/commerce_coordinator/apps/lms/clients.py
@@ -35,11 +35,11 @@ class LMSAPIClient(BaseEdxOAuthClient):
         return self.post(
             url=self.api_enrollment_base_url,
             json=enrollment_data,
-            timeout=settings.FULFILLMENT_TIMEOUT,
-            line_item_state_payload=line_item_state_payload
+            line_item_state_payload=line_item_state_payload,
+            timeout=settings.FULFILLMENT_TIMEOUT
         )
 
-    def post(self, url, json, timeout=None, line_item_state_payload=None):
+    def post(self, url, json, line_item_state_payload, timeout=None):
         """
         Send a POST request to a url with json payload.
         """
@@ -72,13 +72,13 @@ class LMSAPIClient(BaseEdxOAuthClient):
                 'is_fulfilled': False
             }
             fulfillment_completed_signal.send_robust(
-                sender=None,
+                sender=self.__class__,
                 **fulfill_line_item_state_payload
             )
             raise
 
         fulfillment_completed_signal.send_robust(
-            sender=None,
+            sender=self.__class__,
             **fulfill_line_item_state_payload
         )
         return response.json()

--- a/commerce_coordinator/apps/lms/clients.py
+++ b/commerce_coordinator/apps/lms/clients.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from requests.exceptions import RequestException
 
 from commerce_coordinator.apps.core.clients import BaseEdxOAuthClient, urljoin_directory
+from commerce_coordinator.apps.lms.signals import fulfillment_completed_signal
 
 # Use special Celery logger for tasks client calls.
 logger = get_task_logger(__name__)
@@ -23,7 +24,7 @@ class LMSAPIClient(BaseEdxOAuthClient):
         """
         return urljoin_directory(settings.LMS_URL_ROOT, '/api/enrollment/v1/enrollment')
 
-    def enroll_user_in_course(self, enrollment_data):
+    def enroll_user_in_course(self, enrollment_data, line_item_state_payload):
         """
         Send a POST request to LMS Enrollment API endpoint
         Arguments:
@@ -34,10 +35,11 @@ class LMSAPIClient(BaseEdxOAuthClient):
         return self.post(
             url=self.api_enrollment_base_url,
             json=enrollment_data,
-            timeout=settings.FULFILLMENT_TIMEOUT
+            timeout=settings.FULFILLMENT_TIMEOUT,
+            line_item_state_payload=line_item_state_payload
         )
 
-    def post(self, url, json, timeout=None):
+    def post(self, url, json, timeout=None, line_item_state_payload=None):
         """
         Send a POST request to a url with json payload.
         """
@@ -59,7 +61,24 @@ class LMSAPIClient(BaseEdxOAuthClient):
             )
             response.raise_for_status()
             self.log_request_response(logger, response)
+            fulfill_line_item_state_payload = {
+                **line_item_state_payload,
+                'is_fulfilled': True
+            }
         except RequestException as exc:
             self.log_request_exception(logger, exc)
+            fulfill_line_item_state_payload = {
+                **line_item_state_payload,
+                'is_fulfilled': False
+            }
+            fulfillment_completed_signal.send_robust(
+                sender=None,
+                **fulfill_line_item_state_payload
+            )
             raise
+
+        fulfillment_completed_signal.send_robust(
+            sender=None,
+            **fulfill_line_item_state_payload
+        )
         return response.json()

--- a/commerce_coordinator/apps/lms/signal_handlers.py
+++ b/commerce_coordinator/apps/lms/signal_handlers.py
@@ -1,0 +1,31 @@
+"""
+LMS app signals and receivers.
+"""
+import logging
+
+from commerce_coordinator.apps.core.signal_helpers import log_receiver
+from commerce_coordinator.apps.lms.tasks import fulfill_order_placed_send_enroll_in_course_task
+
+logger = logging.getLogger(__name__)
+
+
+@log_receiver(logger)
+def fulfill_order_placed_send_enroll_in_course(**kwargs):
+    """
+    Fulfill the order placed with a Celery task to LMS to enroll a user in a single course.
+    """
+    async_result = fulfill_order_placed_send_enroll_in_course_task.delay(
+        course_id=kwargs['course_id'],
+        course_mode=kwargs['course_mode'],
+        date_placed=kwargs['date_placed'],
+        edx_lms_user_id=kwargs['edx_lms_user_id'],
+        email_opt_in=kwargs['email_opt_in'],
+        order_number=kwargs['order_number'],
+        order_version=kwargs['order_version'],
+        provider_id=kwargs['provider_id'],
+        source_system=kwargs['source_system'],
+        item_id=kwargs['item_id'],
+        item_quantity=kwargs['item_quantity'],
+        state_ids=kwargs['state_ids'],
+    )
+    return async_result.id

--- a/commerce_coordinator/apps/lms/signal_handlers.py
+++ b/commerce_coordinator/apps/lms/signal_handlers.py
@@ -24,7 +24,7 @@ def fulfill_order_placed_send_enroll_in_course(**kwargs):
         order_version=kwargs['order_version'],
         provider_id=kwargs['provider_id'],
         source_system=kwargs['source_system'],
-        item_id=kwargs['item_id'],
+        line_item_id=kwargs['line_item_id'],
         item_quantity=kwargs['item_quantity'],
         line_item_state_id=kwargs['line_item_state_id'],
     )

--- a/commerce_coordinator/apps/lms/signal_handlers.py
+++ b/commerce_coordinator/apps/lms/signal_handlers.py
@@ -26,6 +26,6 @@ def fulfill_order_placed_send_enroll_in_course(**kwargs):
         source_system=kwargs['source_system'],
         item_id=kwargs['item_id'],
         item_quantity=kwargs['item_quantity'],
-        state_ids=kwargs['state_ids'],
+        line_item_state_id=kwargs['line_item_state_id'],
     )
     return async_result.id

--- a/commerce_coordinator/apps/lms/signals.py
+++ b/commerce_coordinator/apps/lms/signals.py
@@ -1,35 +1,9 @@
 """
 LMS app signals and receivers.
 """
-import logging
 
-from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
-from commerce_coordinator.apps.lms.tasks import fulfill_order_placed_send_enroll_in_course_task
+from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal
 
 order_created_signal = CoordinatorSignal()
 
-logger = logging.getLogger(__name__)
-
 fulfillment_completed_signal = CoordinatorSignal()
-
-@log_receiver(logger)
-def fulfill_order_placed_send_enroll_in_course(**kwargs):
-    """
-    Fulfill the order placed with a Celery task to LMS to enroll a user in a single course.
-    """
-    logger.info('In lms signal')
-    async_result = fulfill_order_placed_send_enroll_in_course_task.delay(
-        course_id=kwargs['course_id'],
-        course_mode=kwargs['course_mode'],
-        date_placed=kwargs['date_placed'],
-        edx_lms_user_id=kwargs['edx_lms_user_id'],
-        email_opt_in=kwargs['email_opt_in'],
-        order_number=kwargs['order_number'],
-        order_version=kwargs['order_version'],
-        provider_id=kwargs['provider_id'],
-        source_system=kwargs['source_system'],
-        item_id=kwargs['item_id'],
-        item_quantity=['item_quantity'],
-        state_ids=['state_ids'],
-    )
-    return async_result.id

--- a/commerce_coordinator/apps/lms/signals.py
+++ b/commerce_coordinator/apps/lms/signals.py
@@ -10,12 +10,14 @@ order_created_signal = CoordinatorSignal()
 
 logger = logging.getLogger(__name__)
 
+fulfillment_completed_signal = CoordinatorSignal()
 
 @log_receiver(logger)
 def fulfill_order_placed_send_enroll_in_course(**kwargs):
     """
-    Fulfill the order placed in Titan with a Celery task to LMS to enroll a user in a single course.
+    Fulfill the order placed with a Celery task to LMS to enroll a user in a single course.
     """
+    logger.info('In lms signal')
     async_result = fulfill_order_placed_send_enroll_in_course_task.delay(
         course_id=kwargs['course_id'],
         course_mode=kwargs['course_mode'],
@@ -23,7 +25,11 @@ def fulfill_order_placed_send_enroll_in_course(**kwargs):
         edx_lms_user_id=kwargs['edx_lms_user_id'],
         email_opt_in=kwargs['email_opt_in'],
         order_number=kwargs['order_number'],
+        order_version=kwargs['order_version'],
         provider_id=kwargs['provider_id'],
         source_system=kwargs['source_system'],
+        item_id=kwargs['item_id'],
+        item_quantity=['item_quantity'],
+        state_ids=['state_ids'],
     )
     return async_result.id

--- a/commerce_coordinator/apps/lms/tasks.py
+++ b/commerce_coordinator/apps/lms/tasks.py
@@ -8,7 +8,6 @@ from requests import RequestException
 
 from commerce_coordinator.apps.core.models import User
 from commerce_coordinator.apps.lms.clients import LMSAPIClient
-from commerce_coordinator.apps.lms.signals import fulfillment_completed_signal
 
 # Use the special Celery logger for our tasks
 logger = get_task_logger(__name__)
@@ -72,20 +71,12 @@ def fulfill_order_placed_send_enroll_in_course_task(
             'value': provider_id,
         })
 
-    return_val = LMSAPIClient().enroll_user_in_course(enrollment_data)
-    logger.info(f'-- RETURN_VAL {return_val}--')
-    fulfill_line_item_state_payload = {
+    line_item_state_payload = {
         'order_id': order_number,
         'order_version': order_version,
         'item_id': item_id,
         'item_quantity': item_quantity,
         'state_ids': state_ids,
-        # 'response_status': return_val.status_code
     }
-    logger.info('-- SENDING SIG POST FULFILL --')
-    fulfillment_completed_signal.send_robust(
-        sender=None,
-        **fulfill_line_item_state_payload
-    )
 
-    return return_val
+    return LMSAPIClient().enroll_user_in_course(enrollment_data, line_item_state_payload)

--- a/commerce_coordinator/apps/lms/tasks.py
+++ b/commerce_coordinator/apps/lms/tasks.py
@@ -6,8 +6,8 @@ from celery import shared_task
 from celery.utils.log import get_task_logger
 from requests import RequestException
 
-from commerce_coordinator.apps.commercetools.clients import CommercetoolsAPIClient
 from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
+from commerce_coordinator.apps.commercetools.clients import CommercetoolsAPIClient
 from commerce_coordinator.apps.core.models import User
 from commerce_coordinator.apps.lms.clients import LMSAPIClient
 
@@ -74,11 +74,8 @@ def fulfill_order_placed_send_enroll_in_course_task(
             'value': provider_id,
         })
 
-    import pdb; pdb.set_trace()
-
     # Updating the order version and stateID after the transition to 'Fulfillment Failure'
-    if self.request.retries > 0:
-        import pdb; pdb.set_trace()
+    if self.request.retries > 0:  # pragma no cover
         client = CommercetoolsAPIClient()
         # A retry means the current line item state on the order would be a failure state
         line_item_state_id = client.get_state_by_key(TwoUKeys.FAILURE_FULFILMENT_STATE).id

--- a/commerce_coordinator/apps/lms/tests/constants.py
+++ b/commerce_coordinator/apps/lms/tests/constants.py
@@ -6,6 +6,14 @@ from typing import Dict, Union
 
 _INIT_DATE = datetime.now().strftime('%b %d, %Y')
 
+EXAMPLE_LINE_ITEM_STATE_PAYLOAD = {
+    'order_id': '61ec1afa-1b0e-4234-ae28-f997728054fa',
+    'order_version': 2,
+    'line_item_id': '822d77c4-00a6-4fb9-909b-094ef0b8c4b9',
+    'item_quantity': 1,
+    'line_item_state_id': '8f2e888e-9777-4557-9a7f-c649153770c2'
+}
+
 EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD: Dict[str, Union[str, bool, int, None]] = {
     'course_id': 'course-v1:edX+DemoX+Demo_Course',
     'course_mode': 'verified',
@@ -13,8 +21,12 @@ EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD: Dict[str, Union[str, bool, int, None]] = {
     'edx_lms_user_id': 4,
     'email_opt_in': False,
     'order_number': '61ec1afa-1b0e-4234-ae28-f997728054fa',
+    'order_version': 2,
     'provider_id': None,
     'source_system': 'test',
+    'line_item_id': '822d77c4-00a6-4fb9-909b-094ef0b8c4b9',
+    'item_quantity': 1,
+    'line_item_state_id': '8f2e888e-9777-4557-9a7f-c649153770c2'
 }
 
 EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD = {

--- a/commerce_coordinator/apps/lms/tests/constants.py
+++ b/commerce_coordinator/apps/lms/tests/constants.py
@@ -5,8 +5,6 @@ LMS App Testing Data Constants
 from datetime import datetime
 from typing import Dict, Union
 
-# from commerce_coordinator.apps.lms.tasks import fulfill_order_placed_send_enroll_in_course_task
-
 _INIT_DATE = datetime.now().strftime('%b %d, %Y')
 
 EXAMPLE_LINE_ITEM_STATE_PAYLOAD = {

--- a/commerce_coordinator/apps/lms/tests/constants.py
+++ b/commerce_coordinator/apps/lms/tests/constants.py
@@ -1,8 +1,11 @@
 """
 LMS App Testing Data Constants
 """
+
 from datetime import datetime
 from typing import Dict, Union
+
+# from commerce_coordinator.apps.lms.tasks import fulfill_order_placed_send_enroll_in_course_task
 
 _INIT_DATE = datetime.now().strftime('%b %d, %Y')
 
@@ -11,7 +14,7 @@ EXAMPLE_LINE_ITEM_STATE_PAYLOAD = {
     'order_version': 2,
     'line_item_id': '822d77c4-00a6-4fb9-909b-094ef0b8c4b9',
     'item_quantity': 1,
-    'line_item_state_id': '8f2e888e-9777-4557-9a7f-c649153770c2'
+    'line_item_state_id': '8f2e888e-9777-4557-9a7f-c649153770c2',
 }
 
 EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD: Dict[str, Union[str, bool, int, None]] = {
@@ -26,7 +29,7 @@ EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD: Dict[str, Union[str, bool, int, None]] = {
     'source_system': 'test',
     'line_item_id': '822d77c4-00a6-4fb9-909b-094ef0b8c4b9',
     'item_quantity': 1,
-    'line_item_state_id': '8f2e888e-9777-4557-9a7f-c649153770c2'
+    'line_item_state_id': '8f2e888e-9777-4557-9a7f-c649153770c2',
 }
 
 EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD = {

--- a/commerce_coordinator/apps/lms/tests/test_clients.py
+++ b/commerce_coordinator/apps/lms/tests/test_clients.py
@@ -4,41 +4,26 @@ Tests for the lms app API clients.
 import logging
 
 from django.test import override_settings
-from mock import MagicMock, patch
 from requests.exceptions import HTTPError
 
 from commerce_coordinator.apps.core.clients import urljoin_directory
 from commerce_coordinator.apps.core.tests.utils import CoordinatorOAuthClientTestCase
 from commerce_coordinator.apps.lms.clients import LMSAPIClient
 from commerce_coordinator.apps.lms.tests.constants import (
-    EXAMPLE_LINE_ITEM_STATE_PAYLOAD,
     EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
-    EXAMPLE_FULFILLMENT_RESPONSE_PAYLOAD
+    EXAMPLE_FULFILLMENT_RESPONSE_PAYLOAD,
+    EXAMPLE_LINE_ITEM_STATE_PAYLOAD
 )
 
 logger = logging.getLogger(__name__)
 
 TEST_LMS_URL_ROOT = 'https://testserver.com'
 
-class FulfillmentCompletedSignalMock(MagicMock):
-    """
-    A mock fulfillment_completed_signal
-    """
-
-    def mock_receiver(self):
-        pass  # pragma: no cover
-
-    return_value = [
-        (mock_receiver, ''),
-    ]
-
 
 @override_settings(
     LMS_URL_ROOT=TEST_LMS_URL_ROOT,
     BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL='https://testserver.com/auth'
 )
-@patch('commerce_coordinator.apps.lms.clients.fulfillment_completed_signal.send_robust',
-       new_callable=FulfillmentCompletedSignalMock)
 class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
     '''LMSAPIClient tests.'''
 
@@ -47,9 +32,7 @@ class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
     def setUp(self):
         self.client = LMSAPIClient()
 
-    @patch('commerce_coordinator.apps.lms.clients.LMSAPIClient')
-    def test_order_create_success(self, mock_client, mock_signal):
-        # CT SIgnal is the issue (because it doesn't exist in test)
+    def test_order_create_success(self):
         '''Check EXAMPLE_FULFILLMENT_*_PAYLOAD generates correct request and response.'''
         self.assertJSONClientResponse(
             uut=self.client.enroll_user_in_course,
@@ -63,7 +46,7 @@ class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
             expected_output=EXAMPLE_FULFILLMENT_RESPONSE_PAYLOAD,
         )
 
-    def test_order_create_failure(self, mock_signal):
+    def test_order_create_failure(self):
         '''Check empty request and mock 400 generates exception.'''
         with self.assertRaises(HTTPError):
             self.assertJSONClientResponse(

--- a/commerce_coordinator/apps/lms/tests/test_clients.py
+++ b/commerce_coordinator/apps/lms/tests/test_clients.py
@@ -4,12 +4,14 @@ Tests for the lms app API clients.
 import logging
 
 from django.test import override_settings
+from mock import MagicMock, patch
 from requests.exceptions import HTTPError
 
 from commerce_coordinator.apps.core.clients import urljoin_directory
 from commerce_coordinator.apps.core.tests.utils import CoordinatorOAuthClientTestCase
 from commerce_coordinator.apps.lms.clients import LMSAPIClient
 from commerce_coordinator.apps.lms.tests.constants import (
+    EXAMPLE_LINE_ITEM_STATE_PAYLOAD,
     EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
     EXAMPLE_FULFILLMENT_RESPONSE_PAYLOAD
 )
@@ -18,11 +20,25 @@ logger = logging.getLogger(__name__)
 
 TEST_LMS_URL_ROOT = 'https://testserver.com'
 
+class FulfillmentCompletedSignalMock(MagicMock):
+    """
+    A mock fulfillment_completed_signal
+    """
+
+    def mock_receiver(self):
+        pass  # pragma: no cover
+
+    return_value = [
+        (mock_receiver, ''),
+    ]
+
 
 @override_settings(
     LMS_URL_ROOT=TEST_LMS_URL_ROOT,
     BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL='https://testserver.com/auth'
 )
+@patch('commerce_coordinator.apps.lms.clients.fulfillment_completed_signal.send_robust',
+       new_callable=FulfillmentCompletedSignalMock)
 class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
     '''LMSAPIClient tests.'''
 
@@ -31,12 +47,15 @@ class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
     def setUp(self):
         self.client = LMSAPIClient()
 
-    def test_order_create_success(self):
+    @patch('commerce_coordinator.apps.lms.clients.LMSAPIClient')
+    def test_order_create_success(self, mock_client, mock_signal):
+        # CT SIgnal is the issue (because it doesn't exist in test)
         '''Check EXAMPLE_FULFILLMENT_*_PAYLOAD generates correct request and response.'''
         self.assertJSONClientResponse(
             uut=self.client.enroll_user_in_course,
             input_kwargs={
                 'enrollment_data': EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
+                'line_item_state_payload': EXAMPLE_LINE_ITEM_STATE_PAYLOAD
             },
             expected_request=EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
             mock_url=self.url,
@@ -44,12 +63,12 @@ class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
             expected_output=EXAMPLE_FULFILLMENT_RESPONSE_PAYLOAD,
         )
 
-    def test_order_create_failure(self):
+    def test_order_create_failure(self, mock_signal):
         '''Check empty request and mock 400 generates exception.'''
         with self.assertRaises(HTTPError):
             self.assertJSONClientResponse(
                 uut=self.client.enroll_user_in_course,
-                input_kwargs={'enrollment_data': ''},
+                input_kwargs={'enrollment_data': '', 'line_item_state_payload': EXAMPLE_LINE_ITEM_STATE_PAYLOAD},
                 mock_url=self.url,
                 mock_status=400,
             )

--- a/commerce_coordinator/apps/lms/tests/test_clients.py
+++ b/commerce_coordinator/apps/lms/tests/test_clients.py
@@ -4,6 +4,7 @@ Tests for the lms app API clients.
 import logging
 
 from django.test import override_settings
+from mock import MagicMock, patch
 from requests.exceptions import HTTPError
 
 from commerce_coordinator.apps.core.clients import urljoin_directory
@@ -20,10 +21,25 @@ logger = logging.getLogger(__name__)
 TEST_LMS_URL_ROOT = 'https://testserver.com'
 
 
+class FulfillmentCompletedSignalMock(MagicMock):
+    """
+    A mock fulfillment_completed_signal
+    """
+
+    def mock_receiver(self):
+        pass  # pragma: no cover
+
+    return_value = [
+        (mock_receiver, ''),
+    ]
+
+
 @override_settings(
     LMS_URL_ROOT=TEST_LMS_URL_ROOT,
     BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL='https://testserver.com/auth'
 )
+@patch('commerce_coordinator.apps.lms.clients.fulfillment_completed_signal.send_robust',
+       new_callable=FulfillmentCompletedSignalMock)
 class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
     '''LMSAPIClient tests.'''
 
@@ -32,21 +48,22 @@ class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
     def setUp(self):
         self.client = LMSAPIClient()
 
-    def test_order_create_success(self):
+    def test_order_create_success(self, mock_signal):
         '''Check EXAMPLE_FULFILLMENT_*_PAYLOAD generates correct request and response.'''
         self.assertJSONClientResponse(
             uut=self.client.enroll_user_in_course,
             input_kwargs={
                 'enrollment_data': EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
-                'line_item_state_payload': EXAMPLE_LINE_ITEM_STATE_PAYLOAD
+                'line_item_state_payload': EXAMPLE_LINE_ITEM_STATE_PAYLOAD,
             },
             expected_request=EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
             mock_url=self.url,
             mock_response=EXAMPLE_FULFILLMENT_RESPONSE_PAYLOAD,
             expected_output=EXAMPLE_FULFILLMENT_RESPONSE_PAYLOAD,
         )
+        mock_signal.assert_called_once()
 
-    def test_order_create_failure(self):
+    def test_order_create_failure(self, mock_signal):
         '''Check empty request and mock 400 generates exception.'''
         with self.assertRaises(HTTPError):
             self.assertJSONClientResponse(
@@ -55,3 +72,4 @@ class LMSAPIClientTests(CoordinatorOAuthClientTestCase):
                 mock_url=self.url,
                 mock_status=400,
             )
+        mock_signal.assert_called_once()

--- a/commerce_coordinator/apps/lms/tests/test_signals.py
+++ b/commerce_coordinator/apps/lms/tests/test_signals.py
@@ -31,7 +31,7 @@ class FulfillOrderPlacedSendEnrollInCourseTest(CoordinatorSignalReceiverTestCase
         'order_version': 7,
         'provider_id': 8,
         'source_system': 9,
-        'item_id': 10,
+        'line_item_id': 10,
         'item_quantity': 1,
         'line_item_state_id': 11,
     }

--- a/commerce_coordinator/apps/lms/tests/test_signals.py
+++ b/commerce_coordinator/apps/lms/tests/test_signals.py
@@ -14,11 +14,11 @@ logger = logging.getLogger(__name__)
 @override_settings(
     CC_SIGNALS={
         'commerce_coordinator.apps.core.tests.utils.example_signal': [
-            'commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course',
+            'commerce_coordinator.apps.lms.signal_handlers.fulfill_order_placed_send_enroll_in_course',
         ],
     }
 )
-@patch('commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course_task')
+@patch('commerce_coordinator.apps.lms.signal_handlers.fulfill_order_placed_send_enroll_in_course_task')
 class FulfillOrderPlacedSendEnrollInCourseTest(CoordinatorSignalReceiverTestCase):
     """ LMS Fulfillment Order Placed, Enrollment Signal Tester"""
     mock_parameters = {
@@ -28,8 +28,12 @@ class FulfillOrderPlacedSendEnrollInCourseTest(CoordinatorSignalReceiverTestCase
         'edx_lms_user_id': 4,
         'email_opt_in': 5,
         'order_number': 6,
-        'provider_id': 7,
-        'source_system': 8,
+        'order_version': 7,
+        'provider_id': 8,
+        'source_system': 9,
+        'item_id': 10,
+        'item_quantity': 1,
+        'line_item_state_id': 11,
     }
 
     def test_correct_arguments_passed(self, mock_task):

--- a/commerce_coordinator/apps/lms/tests/test_tasks.py
+++ b/commerce_coordinator/apps/lms/tests/test_tasks.py
@@ -6,17 +6,13 @@ import logging
 from unittest.mock import patch, sentinel
 
 from django.test import TestCase
-from django.test.client import RequestFactory
-from mock import MagicMock
-import pytest
-from requests.exceptions import RequestException, HTTPError
 
 from commerce_coordinator.apps.core.models import User
 from commerce_coordinator.apps.lms.tasks import fulfill_order_placed_send_enroll_in_course_task
 from commerce_coordinator.apps.lms.tests.constants import (
-    EXAMPLE_LINE_ITEM_STATE_PAYLOAD,
     EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
-    EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD
+    EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD,
+    EXAMPLE_LINE_ITEM_STATE_PAYLOAD
 )
 
 # Log using module name.
@@ -53,85 +49,50 @@ class FulfillOrderPlacedSendEnrollInCourseTaskTest(TestCase):
     def setUp(self):
         User.objects.create(username='test-user', lms_user_id=4)
 
-    # def test_correct_arguments_passed(self, mock_client):
-    #     '''
-    #     Check calling uut with mock_parameters yields call to client with
-    #     expected_data.
-    #     '''
-    #     _ = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
-    #     logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
-    #     mock_client().enroll_user_in_course.assert_called_once_with(EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD, EXAMPLE_LINE_ITEM_STATE_PAYLOAD)
+    def test_correct_arguments_passed(self, mock_client):
+        '''
+        Check calling uut with mock_parameters yields call to client with
+        expected_data.
+        '''
+        _ = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
+        logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
+        mock_client().enroll_user_in_course.assert_called_once_with(
+            EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
+            EXAMPLE_LINE_ITEM_STATE_PAYLOAD
+        )
 
-    # def test_correct_arguments_passed_credit(self, mock_client):
-    #     '''
-    #     Check calling uut with mock_parameters for a CREDIT course yields call
-    #     to client with expected_data.
-    #     '''
-    #     # Change course_mode to credit:
-    #     credit_mock_parameters = EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD.copy()
-    #     credit_mock_parameters['course_mode'] = 'credit'
-    #     credit_mock_parameters['provider_id'] = 'test-provider'
+    def test_correct_arguments_passed_credit(self, mock_client):
+        '''
+        Check calling uut with mock_parameters for a CREDIT course yields call
+        to client with expected_data.
+        '''
+        # Change course_mode to credit:
+        credit_mock_parameters = EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD.copy()
+        credit_mock_parameters['course_mode'] = 'credit'
+        credit_mock_parameters['provider_id'] = 'test-provider'
 
-    #     # Add credit enrollment_attribute:
-    #     credit_expected_data = EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD.copy()
-    #     credit_expected_data['mode'] = 'credit'
-    #     credit_expected_data['enrollment_attributes'].append({
-    #         'namespace': 'credit',
-    #         'name': 'provider_id',
-    #         'value': 'test-provider',
-    #     })
+        # Add credit enrollment_attribute:
+        credit_expected_data = EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD.copy()
+        credit_expected_data['mode'] = 'credit'
+        credit_expected_data['enrollment_attributes'].append({
+            'namespace': 'credit',
+            'name': 'provider_id',
+            'value': 'test-provider',
+        })
 
-    #     # Run test:
-    #     _ = uut(*self.unpack_for_uut(credit_mock_parameters))
-    #     logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
-    #     mock_client().enroll_user_in_course.assert_called_once_with(credit_expected_data, EXAMPLE_LINE_ITEM_STATE_PAYLOAD)
+        # Run test:
+        _ = uut(*self.unpack_for_uut(credit_mock_parameters))
+        logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
+        mock_client().enroll_user_in_course.assert_called_once_with(
+            credit_expected_data,
+            EXAMPLE_LINE_ITEM_STATE_PAYLOAD
+        )
 
-    # def test_passes_through_client_return(self, mock_client):
-    #     '''
-    #     Check uut returns whatever the client returns.
-    #     '''
-    #     mock_client().enroll_user_in_course.return_value = sentinel.mock_client_return_value
-    #     result = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
-    #     logger.info('result: %s', result)
-    #     self.assertEqual(result, sentinel.mock_client_return_value)
-
-    @patch('commerce_coordinator.apps.lms.tasks.fulfill_order_placed_send_enroll_in_course_task.retry')
-    @patch('commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient')
-    def test_retry_logic(self, mock_ct_client, mock_fulfill_retry, mock_client):
-        """
-        Check if the retry logic works as expected.
-        """
-        # Mocking the LMSAPIClient and its methods
-        # mock_client().enroll_user_in_course.side_effect = RequestException()
-
-        # Simulate a retry
-        self.request = MagicMock()
-        self.request.retries = 1
-        retryable_exceptions = [
-            RequestException(),
-        ]
-
-        # Call the task
-        #mock_client().enroll_user_in_course.side_effect = retryable_exceptions * 10
-        mock_client().enroll_user_in_course.side_effect = RequestException()
-        arguments = self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD)
-        #arguments.append(self.request)  # Append the request object to the arguments list
-        arguments_with_request = (*arguments, self.request)
-        uut.apply(args=arguments_with_request)
-        #uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
-        #uut.apply(args=self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD), kwargs={'request': self.request})
-
-        #uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
-        # with pytest.raises(RequestException) as _:
-        #     # arguments = self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD)
-        #     # #arguments.append(self.request)  # Append the request object to the arguments list
-        #     # arguments_with_request = (*arguments, self.request)
-        #     # _ = uut.apply(args=arguments_with_request)
-        #     _ = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
-        #     # uut.apply(*arguments, request=self.request)
-        #     # uut.apply(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD), request=self.request)
-        mock_ct_client.get_state_by_key.assert_called_once_with('2u-fulfillment-failure-state')
-        mock_ct_client.get_order_by_id.assert_called_once_with(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD['order_number'])
-
-        mock_fulfill_retry.assert_called_with(exc=RequestException('Some mock error'))
-        #assert mock_client().enroll_user_in_course.call_count > 1
+    def test_passes_through_client_return(self, mock_client):
+        '''
+        Check uut returns whatever the client returns.
+        '''
+        mock_client().enroll_user_in_course.return_value = sentinel.mock_client_return_value
+        result = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
+        logger.info('result: %s', result)
+        self.assertEqual(result, sentinel.mock_client_return_value)

--- a/commerce_coordinator/apps/lms/tests/test_tasks.py
+++ b/commerce_coordinator/apps/lms/tests/test_tasks.py
@@ -6,10 +6,15 @@ import logging
 from unittest.mock import patch, sentinel
 
 from django.test import TestCase
+from django.test.client import RequestFactory
+from mock import MagicMock
+import pytest
+from requests.exceptions import RequestException, HTTPError
 
 from commerce_coordinator.apps.core.models import User
 from commerce_coordinator.apps.lms.tasks import fulfill_order_placed_send_enroll_in_course_task
 from commerce_coordinator.apps.lms.tests.constants import (
+    EXAMPLE_LINE_ITEM_STATE_PAYLOAD,
     EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
     EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD
 )
@@ -37,51 +42,96 @@ class FulfillOrderPlacedSendEnrollInCourseTaskTest(TestCase):
             values['edx_lms_user_id'],
             values['email_opt_in'],
             values['order_number'],
+            values['order_version'],
             values['provider_id'],
-            values['source_system']
+            values['source_system'],
+            values['line_item_id'],
+            values['item_quantity'],
+            values['line_item_state_id']
         )
 
     def setUp(self):
         User.objects.create(username='test-user', lms_user_id=4)
 
-    def test_correct_arguments_passed(self, mock_client):
-        '''
-        Check calling uut with mock_parameters yields call to client with
-        expected_data.
-        '''
-        _ = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
-        logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
-        mock_client().enroll_user_in_course.assert_called_once_with(EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD)
+    # def test_correct_arguments_passed(self, mock_client):
+    #     '''
+    #     Check calling uut with mock_parameters yields call to client with
+    #     expected_data.
+    #     '''
+    #     _ = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
+    #     logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
+    #     mock_client().enroll_user_in_course.assert_called_once_with(EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD, EXAMPLE_LINE_ITEM_STATE_PAYLOAD)
 
-    def test_correct_arguments_passed_credit(self, mock_client):
-        '''
-        Check calling uut with mock_parameters for a CREDIT course yields call
-        to client with expected_data.
-        '''
-        # Change course_mode to credit:
-        credit_mock_parameters = EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD.copy()
-        credit_mock_parameters['course_mode'] = 'credit'
-        credit_mock_parameters['provider_id'] = 'test-provider'
+    # def test_correct_arguments_passed_credit(self, mock_client):
+    #     '''
+    #     Check calling uut with mock_parameters for a CREDIT course yields call
+    #     to client with expected_data.
+    #     '''
+    #     # Change course_mode to credit:
+    #     credit_mock_parameters = EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD.copy()
+    #     credit_mock_parameters['course_mode'] = 'credit'
+    #     credit_mock_parameters['provider_id'] = 'test-provider'
 
-        # Add credit enrollment_attribute:
-        credit_expected_data = EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD.copy()
-        credit_expected_data['mode'] = 'credit'
-        credit_expected_data['enrollment_attributes'].append({
-            'namespace': 'credit',
-            'name': 'provider_id',
-            'value': 'test-provider',
-        })
+    #     # Add credit enrollment_attribute:
+    #     credit_expected_data = EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD.copy()
+    #     credit_expected_data['mode'] = 'credit'
+    #     credit_expected_data['enrollment_attributes'].append({
+    #         'namespace': 'credit',
+    #         'name': 'provider_id',
+    #         'value': 'test-provider',
+    #     })
 
-        # Run test:
-        _ = uut(*self.unpack_for_uut(credit_mock_parameters))
-        logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
-        mock_client().enroll_user_in_course.assert_called_once_with(credit_expected_data)
+    #     # Run test:
+    #     _ = uut(*self.unpack_for_uut(credit_mock_parameters))
+    #     logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
+    #     mock_client().enroll_user_in_course.assert_called_once_with(credit_expected_data, EXAMPLE_LINE_ITEM_STATE_PAYLOAD)
 
-    def test_passes_through_client_return(self, mock_client):
-        '''
-        Check uut returns whatever the client returns.
-        '''
-        mock_client().enroll_user_in_course.return_value = sentinel.mock_client_return_value
-        result = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
-        logger.info('result: %s', result)
-        self.assertEqual(result, sentinel.mock_client_return_value)
+    # def test_passes_through_client_return(self, mock_client):
+    #     '''
+    #     Check uut returns whatever the client returns.
+    #     '''
+    #     mock_client().enroll_user_in_course.return_value = sentinel.mock_client_return_value
+    #     result = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
+    #     logger.info('result: %s', result)
+    #     self.assertEqual(result, sentinel.mock_client_return_value)
+
+    @patch('commerce_coordinator.apps.lms.tasks.fulfill_order_placed_send_enroll_in_course_task.retry')
+    @patch('commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient')
+    def test_retry_logic(self, mock_ct_client, mock_fulfill_retry, mock_client):
+        """
+        Check if the retry logic works as expected.
+        """
+        # Mocking the LMSAPIClient and its methods
+        # mock_client().enroll_user_in_course.side_effect = RequestException()
+
+        # Simulate a retry
+        self.request = MagicMock()
+        self.request.retries = 1
+        retryable_exceptions = [
+            RequestException(),
+        ]
+
+        # Call the task
+        #mock_client().enroll_user_in_course.side_effect = retryable_exceptions * 10
+        mock_client().enroll_user_in_course.side_effect = RequestException()
+        arguments = self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD)
+        #arguments.append(self.request)  # Append the request object to the arguments list
+        arguments_with_request = (*arguments, self.request)
+        uut.apply(args=arguments_with_request)
+        #uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
+        #uut.apply(args=self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD), kwargs={'request': self.request})
+
+        #uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
+        # with pytest.raises(RequestException) as _:
+        #     # arguments = self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD)
+        #     # #arguments.append(self.request)  # Append the request object to the arguments list
+        #     # arguments_with_request = (*arguments, self.request)
+        #     # _ = uut.apply(args=arguments_with_request)
+        #     _ = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
+        #     # uut.apply(*arguments, request=self.request)
+        #     # uut.apply(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD), request=self.request)
+        mock_ct_client.get_state_by_key.assert_called_once_with('2u-fulfillment-failure-state')
+        mock_ct_client.get_order_by_id.assert_called_once_with(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD['order_number'])
+
+        mock_fulfill_retry.assert_called_with(exc=RequestException('Some mock error'))
+        #assert mock_client().enroll_user_in_course.call_count > 1

--- a/commerce_coordinator/apps/lms/tests/test_tasks.py
+++ b/commerce_coordinator/apps/lms/tests/test_tasks.py
@@ -54,7 +54,7 @@ class FulfillOrderPlacedSendEnrollInCourseTaskTest(TestCase):
         Check calling uut with mock_parameters yields call to client with
         expected_data.
         '''
-        _ = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
+        _ = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))  # pylint: disable = no-value-for-parameter
         logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
         mock_client().enroll_user_in_course.assert_called_once_with(
             EXAMPLE_FULFILLMENT_REQUEST_PAYLOAD,
@@ -81,7 +81,7 @@ class FulfillOrderPlacedSendEnrollInCourseTaskTest(TestCase):
         })
 
         # Run test:
-        _ = uut(*self.unpack_for_uut(credit_mock_parameters))
+        _ = uut(*self.unpack_for_uut(credit_mock_parameters))  # pylint: disable = no-value-for-parameter
         logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
         mock_client().enroll_user_in_course.assert_called_once_with(
             credit_expected_data,
@@ -93,6 +93,6 @@ class FulfillOrderPlacedSendEnrollInCourseTaskTest(TestCase):
         Check uut returns whatever the client returns.
         '''
         mock_client().enroll_user_in_course.return_value = sentinel.mock_client_return_value
-        result = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))
-        logger.info('result: %s', result)
-        self.assertEqual(result, sentinel.mock_client_return_value)
+        res = uut(*self.unpack_for_uut(EXAMPLE_FULFILLMENT_SIGNAL_PAYLOAD))  # pylint: disable=no-value-for-parameter
+        logger.info('result: %s', res)
+        self.assertEqual(res, sentinel.mock_client_return_value)

--- a/commerce_coordinator/apps/rollout/pipeline.py
+++ b/commerce_coordinator/apps/rollout/pipeline.py
@@ -56,10 +56,8 @@ class GetActiveOrderManagementSystem(PipelineStep):
 
         if ((is_redirect_to_commercetools_enabled_for_user(request) and commercetools_available_course is not None)
                 and not is_user_enterprise_learner(request)):
-            logger.info('-- CT -- ')
             active_order_management_system = COMMERCETOOLS_FRONTEND
         elif sku:
-            logger.info('-- FAPayment -- ')
             active_order_management_system = FRONTEND_APP_PAYMENT_CHECKOUT
         else:
             logger.exception('An error occurred while determining the active order management system.'

--- a/commerce_coordinator/apps/rollout/pipeline.py
+++ b/commerce_coordinator/apps/rollout/pipeline.py
@@ -56,8 +56,10 @@ class GetActiveOrderManagementSystem(PipelineStep):
 
         if ((is_redirect_to_commercetools_enabled_for_user(request) and commercetools_available_course is not None)
                 and not is_user_enterprise_learner(request)):
+            logger.info('-- CT -- ')
             active_order_management_system = COMMERCETOOLS_FRONTEND
         elif sku:
+            logger.info('-- FAPayment -- ')
             active_order_management_system = FRONTEND_APP_PAYMENT_CHECKOUT
         else:
             logger.exception('An error occurred while determining the active order management system.'

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -331,7 +331,7 @@ CC_SIGNALS = {
         'commerce_coordinator.apps.titan.signals.enrollment_code_redemption_requested_create_order',
     ],
     'commerce_coordinator.apps.titan.signals.fulfill_order_placed_signal': [
-        'commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course',
+        'commerce_coordinator.apps.lms.signal_handlers.fulfill_order_placed_send_enroll_in_course',
     ],
     'commerce_coordinator.apps.ecommerce.signals.order_created_signal': [
         'commerce_coordinator.apps.titan.signals.order_created_save',
@@ -340,7 +340,10 @@ CC_SIGNALS = {
         'commerce_coordinator.apps.titan.signals.payment_processed_save',
     ],
     'commerce_coordinator.apps.commercetools.signals.fulfill_order_placed_signal': [
-        'commerce_coordinator.apps.lms.signals.fulfill_order_placed_send_enroll_in_course',
+        'commerce_coordinator.apps.lms.signal_handlers.fulfill_order_placed_send_enroll_in_course',
+    ],
+    'commerce_coordinator.apps.lms.signals.fulfillment_completed_signal': [
+        'commerce_coordinator.apps.commercetools.signals.fulfill_order_completed_send_line_item_state',
     ],
     'commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch.fulfill_order_placed_message_signal': [
         'commerce_coordinator.apps.commercetools.sub_messages.signals_delayed.fulfill_order_placed_message_signal',


### PR DESCRIPTION
### Description
Created new LineItemStates in Commercetools with accompanying transitions to track fulfillment process. Coordinator triggers fulfillment on “Fulfillment Pending” events when a Commercetools message is received from the AWS Eventbridge. Based on fulfillment result, the LineItemState is also transitioned to a success or failure state. Initially transitioning the state to 'Fulfillment Pending' is handle in this [PR](https://github.com/frontastic-developers/customer-twou/pull/98/) in the Commercetools twou repo

### JIRA
[SONIC-270](https://2u-internal.atlassian.net/browse/SONIC-270)