### PR TITLE
fix: matching f-a-ecomms returns exactly

### DIFF
--- a/commerce_coordinator/apps/commercetools/catalog_info/constants.py
+++ b/commerce_coordinator/apps/commercetools/catalog_info/constants.py
@@ -23,7 +23,7 @@ LS_OUT_PREFERENCES = [Languages.ENGLISH, Languages.US_ENGLISH]
 HIDE_CODE_FOR_CURRENCIES = ['USD', 'EUR', 'INR', 'JPY']
 """Currencies to hide the code on, so $12 isn't $12 USD."""
 
-SEND_MONEY_AS_DECIMAL = True
+SEND_MONEY_AS_DECIMAL_STRING = True
 """Sends money values as decimal numbers only ('$123.99 AUD' becomes '123.99' when True)"""
 
 DEFAULT_ORDER_EXPANSION = (

--- a/commerce_coordinator/apps/commercetools/catalog_info/constants.py
+++ b/commerce_coordinator/apps/commercetools/catalog_info/constants.py
@@ -23,6 +23,9 @@ LS_OUT_PREFERENCES = [Languages.ENGLISH, Languages.US_ENGLISH]
 HIDE_CODE_FOR_CURRENCIES = ['USD', 'EUR', 'INR', 'JPY']
 """Currencies to hide the code on, so $12 isn't $12 USD."""
 
+SEND_MONEY_AS_DECIMAL = True
+"""Sends money values as decimal numbers only ('$123.99 AUD' becomes '123.99' when True)"""
+
 DEFAULT_ORDER_EXPANSION = (
     "state",
     "paymentInfo.payments[*]",

--- a/commerce_coordinator/apps/commercetools/catalog_info/utils.py
+++ b/commerce_coordinator/apps/commercetools/catalog_info/utils.py
@@ -12,7 +12,7 @@ from currencies import Currency
 from commerce_coordinator.apps.commercetools.catalog_info.constants import (
     HIDE_CODE_FOR_CURRENCIES,
     LS_OUT_PREFERENCES,
-    SEND_MONEY_AS_DECIMAL,
+    SEND_MONEY_AS_DECIMAL_STRING,
     Languages
 )
 
@@ -74,7 +74,7 @@ def un_ls(string_dict: LSLike, preferred_lang: Optional[str] = None):
         return string_dict[langs_available[0]]
 
 
-def price_to_string(price: CTPrice, money_as_decimal=False) -> str:
+def price_to_string(price: CTPrice, money_as_decimal_string=False) -> str:
     """
     Convert Commercetools price to a string.
 
@@ -82,22 +82,22 @@ def price_to_string(price: CTPrice, money_as_decimal=False) -> str:
 
     Args:
         price (CTPrice): Price value
-        money_as_decimal (bool, optional): Should all money be returned as a decimal?
+        money_as_decimal_string (bool, optional): Should all money be returned as a decimal?
 
     Returns:
         string: A string representation
 
     """
-    return typed_money_to_string(price.value, money_as_decimal)
+    return typed_money_to_string(price.value, money_as_decimal_string)
 
 
-def typed_money_to_string(money: CTTypedMoney, money_as_decimal=False) -> str:
+def typed_money_to_string(money: CTTypedMoney, money_as_decimal_string=False) -> str:
     """
     Convert Commercetools typed money to a string.
 
     Args:
         money (TypedMoney): The value of meny to be stringified in its native locale.
-        money_as_decimal (bool, optional): Should all money be returned as a decimal?
+        money_as_decimal_string (bool, optional): Should all money be returned as a decimal?
 
     Returns:
         string: A string representation
@@ -106,7 +106,7 @@ def typed_money_to_string(money: CTTypedMoney, money_as_decimal=False) -> str:
     cur = Currency(money.currency_code)
 
     def _format(cost):
-        if money_as_decimal:  # pragma no cover
+        if money_as_decimal_string:  # pragma no cover
             # This is used to support legacy ecomm mfe
             return str(cost)
 

--- a/commerce_coordinator/apps/commercetools/catalog_info/utils.py
+++ b/commerce_coordinator/apps/commercetools/catalog_info/utils.py
@@ -12,6 +12,7 @@ from currencies import Currency
 from commerce_coordinator.apps.commercetools.catalog_info.constants import (
     HIDE_CODE_FOR_CURRENCIES,
     LS_OUT_PREFERENCES,
+    SEND_MONEY_AS_DECIMAL,
     Languages
 )
 
@@ -73,7 +74,7 @@ def un_ls(string_dict: LSLike, preferred_lang: Optional[str] = None):
         return string_dict[langs_available[0]]
 
 
-def price_to_string(price: CTPrice) -> str:
+def price_to_string(price: CTPrice, money_as_decimal=False) -> str:
     """
     Convert Commercetools price to a string.
 
@@ -81,20 +82,22 @@ def price_to_string(price: CTPrice) -> str:
 
     Args:
         price (CTPrice): Price value
+        money_as_decimal (bool, optional): Should all money be returned as a decimal?
 
     Returns:
         string: A string representation
 
     """
-    return typed_money_to_string(price.value)
+    return typed_money_to_string(price.value, money_as_decimal)
 
 
-def typed_money_to_string(money: CTTypedMoney) -> str:
+def typed_money_to_string(money: CTTypedMoney, money_as_decimal=False) -> str:
     """
     Convert Commercetools typed money to a string.
 
     Args:
         money (TypedMoney): The value of meny to be stringified in its native locale.
+        money_as_decimal (bool, optional): Should all money be returned as a decimal?
 
     Returns:
         string: A string representation
@@ -103,6 +106,10 @@ def typed_money_to_string(money: CTTypedMoney) -> str:
     cur = Currency(money.currency_code)
 
     def _format(cost):
+        if money_as_decimal:  # pragma no cover
+            # This is used to support legacy ecomm mfe
+            return str(cost)
+
         if money.currency_code in HIDE_CODE_FOR_CURRENCIES:
             return cur.get_money_format(cost)
 

--- a/commerce_coordinator/apps/commercetools/data.py
+++ b/commerce_coordinator/apps/commercetools/data.py
@@ -54,8 +54,8 @@ def convert_line_item(li: CTLineItem) -> Line:
         course_organization="",
         description=un_ls(li.name),
         status="PAID",
-        line_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL_STRING),
-        unit_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL_STRING)
+        line_price_excl_tax=price_to_string(li.price, money_as_decimal_string=SEND_MONEY_AS_DECIMAL_STRING),
+        unit_price_excl_tax=price_to_string(li.price, money_as_decimal_string=SEND_MONEY_AS_DECIMAL_STRING)
     )
 
 
@@ -109,7 +109,7 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
         lines=[convert_line_item(x) for x in order.line_items],
         billing_address=convert_address(order.billing_address),
         date_placed=order.last_modified_at,
-        total_excl_tax=typed_money_to_string(order.total_price, SEND_MONEY_AS_DECIMAL_STRING),
+        total_excl_tax=typed_money_to_string(order.total_price, money_as_decimal_string=SEND_MONEY_AS_DECIMAL_STRING),
         # in dev systems, this isn't set... so let's use UUID, otherwise, let's rely on order number
         number=order.id,  # Long-term: this_or(order.order_number, order.id),
         currency=order.total_price.currency_code,
@@ -119,7 +119,8 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
         order_product_ids=", ".join([convert_line_item_prod_id(x) for x in order.line_items]),
         basket_discounts=convert_direct_discount(order.direct_discounts),
         contains_credit_seat="True",
-        discount=typed_money_to_string(order.discount_on_total_price.discounted_amount, SEND_MONEY_AS_DECIMAL_STRING)
+        discount=typed_money_to_string(order.discount_on_total_price.discounted_amount,
+                                       money_as_decimal_string=SEND_MONEY_AS_DECIMAL_STRING)
         if order.discount_on_total_price else None,  # NYI
         enable_hoist_order_history="False",  # ?
         enterprise_learner_portal_url="about:blank",
@@ -132,7 +133,7 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
                 ),
                 order.taxed_price.total_tax
             ),
-            SEND_MONEY_AS_DECIMAL_STRING
+            money_as_decimal_string=SEND_MONEY_AS_DECIMAL_STRING
         ),
         vouchers=this_or(
             convert_discount_code_info(order.discount_codes),

--- a/commerce_coordinator/apps/commercetools/data.py
+++ b/commerce_coordinator/apps/commercetools/data.py
@@ -11,7 +11,7 @@ from commercetools.platform.models import Order as CTOrder
 from commercetools.platform.models import PaymentInfo as CTPaymentInfo
 from django.conf import settings
 
-from commerce_coordinator.apps.commercetools.catalog_info.constants import SEND_MONEY_AS_DECIMAL, EdXFieldNames
+from commerce_coordinator.apps.commercetools.catalog_info.constants import SEND_MONEY_AS_DECIMAL_STRING, EdXFieldNames
 from commerce_coordinator.apps.commercetools.catalog_info.utils import (
     attribute_dict,
     price_to_string,
@@ -54,8 +54,8 @@ def convert_line_item(li: CTLineItem) -> Line:
         course_organization="",
         description=un_ls(li.name),
         status="PAID",
-        line_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL),
-        unit_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL)
+        line_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL_STRING),
+        unit_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL_STRING)
     )
 
 
@@ -109,7 +109,7 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
         lines=[convert_line_item(x) for x in order.line_items],
         billing_address=convert_address(order.billing_address),
         date_placed=order.last_modified_at,
-        total_excl_tax=typed_money_to_string(order.total_price, SEND_MONEY_AS_DECIMAL),
+        total_excl_tax=typed_money_to_string(order.total_price, SEND_MONEY_AS_DECIMAL_STRING),
         # in dev systems, this isn't set... so let's use UUID, otherwise, let's rely on order number
         number=order.id,  # Long-term: this_or(order.order_number, order.id),
         currency=order.total_price.currency_code,
@@ -119,7 +119,7 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
         order_product_ids=", ".join([convert_line_item_prod_id(x) for x in order.line_items]),
         basket_discounts=convert_direct_discount(order.direct_discounts),
         contains_credit_seat="True",
-        discount=typed_money_to_string(order.discount_on_total_price.discounted_amount, SEND_MONEY_AS_DECIMAL)
+        discount=typed_money_to_string(order.discount_on_total_price.discounted_amount, SEND_MONEY_AS_DECIMAL_STRING)
         if order.discount_on_total_price else None,  # NYI
         enable_hoist_order_history="False",  # ?
         enterprise_learner_portal_url="about:blank",
@@ -132,7 +132,7 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
                 ),
                 order.taxed_price.total_tax
             ),
-            SEND_MONEY_AS_DECIMAL
+            SEND_MONEY_AS_DECIMAL_STRING
         ),
         vouchers=this_or(
             convert_discount_code_info(order.discount_codes),

--- a/commerce_coordinator/apps/commercetools/data.py
+++ b/commerce_coordinator/apps/commercetools/data.py
@@ -11,7 +11,7 @@ from commercetools.platform.models import Order as CTOrder
 from commercetools.platform.models import PaymentInfo as CTPaymentInfo
 from django.conf import settings
 
-from commerce_coordinator.apps.commercetools.catalog_info.constants import EdXFieldNames
+from commerce_coordinator.apps.commercetools.catalog_info.constants import SEND_MONEY_AS_DECIMAL, EdXFieldNames
 from commerce_coordinator.apps.commercetools.catalog_info.utils import (
     attribute_dict,
     price_to_string,
@@ -54,8 +54,8 @@ def convert_line_item(li: CTLineItem) -> Line:
         course_organization="",
         description=un_ls(li.name),
         status="PAID",
-        line_price_excl_tax=price_to_string(li.price),
-        unit_price_excl_tax=price_to_string(li.price)
+        line_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL),
+        unit_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL)
     )
 
 
@@ -109,7 +109,7 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
         lines=[convert_line_item(x) for x in order.line_items],
         billing_address=convert_address(order.billing_address),
         date_placed=order.last_modified_at,
-        total_excl_tax=typed_money_to_string(order.total_price),
+        total_excl_tax=typed_money_to_string(order.total_price, SEND_MONEY_AS_DECIMAL),
         # in dev systems, this isn't set... so let's use UUID, otherwise, let's rely on order number
         number=order.id,  # Long-term: this_or(order.order_number, order.id),
         currency=order.total_price.currency_code,
@@ -119,7 +119,7 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
         order_product_ids=", ".join([convert_line_item_prod_id(x) for x in order.line_items]),
         basket_discounts=convert_direct_discount(order.direct_discounts),
         contains_credit_seat="True",
-        discount=typed_money_to_string(order.discount_on_total_price.discounted_amount)
+        discount=typed_money_to_string(order.discount_on_total_price.discounted_amount, SEND_MONEY_AS_DECIMAL)
         if order.discount_on_total_price else None,  # NYI
         enable_hoist_order_history="False",  # ?
         enterprise_learner_portal_url="about:blank",
@@ -131,7 +131,8 @@ def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrde
                     order.discount_on_total_price.discounted_amount if order.discount_on_total_price else None
                 ),
                 order.taxed_price.total_tax
-            )
+            ),
+            SEND_MONEY_AS_DECIMAL
         ),
         vouchers=this_or(
             convert_discount_code_info(order.discount_codes),

--- a/commerce_coordinator/apps/commercetools/tests/test_data.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_data.py
@@ -21,7 +21,7 @@ from commercetools.platform.models import Reference as CTReference
 from commercetools.platform.models import ReferenceTypeId as CTReferenceTypeId
 from commercetools.platform.models import TypeReference as CTTypeReference
 
-from commerce_coordinator.apps.commercetools.catalog_info.constants import EdXFieldNames
+from commerce_coordinator.apps.commercetools.catalog_info.constants import SEND_MONEY_AS_DECIMAL, EdXFieldNames
 from commerce_coordinator.apps.commercetools.catalog_info.utils import attribute_dict, price_to_string, un_ls
 from commerce_coordinator.apps.commercetools.data import (
     convert_address,
@@ -127,8 +127,8 @@ class TestCTOrderConversionToLegacyOrders(TestCase):
                 course_organization="",
                 description=un_ls(li.name),
                 status="PAID",
-                line_price_excl_tax=price_to_string(li.price),
-                unit_price_excl_tax=price_to_string(li.price)
+                line_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL),
+                unit_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL)
             )
         )
 

--- a/commerce_coordinator/apps/commercetools/tests/test_data.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_data.py
@@ -21,7 +21,7 @@ from commercetools.platform.models import Reference as CTReference
 from commercetools.platform.models import ReferenceTypeId as CTReferenceTypeId
 from commercetools.platform.models import TypeReference as CTTypeReference
 
-from commerce_coordinator.apps.commercetools.catalog_info.constants import SEND_MONEY_AS_DECIMAL, EdXFieldNames
+from commerce_coordinator.apps.commercetools.catalog_info.constants import SEND_MONEY_AS_DECIMAL_STRING, EdXFieldNames
 from commerce_coordinator.apps.commercetools.catalog_info.utils import attribute_dict, price_to_string, un_ls
 from commerce_coordinator.apps.commercetools.data import (
     convert_address,
@@ -127,8 +127,8 @@ class TestCTOrderConversionToLegacyOrders(TestCase):
                 course_organization="",
                 description=un_ls(li.name),
                 status="PAID",
-                line_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL),
-                unit_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL)
+                line_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL_STRING),
+                unit_price_excl_tax=price_to_string(li.price, SEND_MONEY_AS_DECIMAL_STRING)
             )
         )
 

--- a/commerce_coordinator/apps/frontend_app_ecommerce/tests/test_views.py
+++ b/commerce_coordinator/apps/frontend_app_ecommerce/tests/test_views.py
@@ -104,7 +104,7 @@ class OrdersViewTests(TestCase):
         response = self.client.get(reverse('frontend_app_ecommerce:order_history'), ORDER_HISTORY_GET_PARAMETERS)
 
         # Check expected response
-        self.assertEqual(response.json()[1], ECOMMERCE_REQUEST_EXPECTED_RESPONSE['results'][0])
+        self.assertEqual(response.json()['results'][1], ECOMMERCE_REQUEST_EXPECTED_RESPONSE['results'][0])
 
     def test_view_passes_username(self, _mock_ctorders, mock_ecommerce_client):
         """Check logged in user's username is passed to the ecommerce client."""

--- a/commerce_coordinator/apps/frontend_app_ecommerce/views.py
+++ b/commerce_coordinator/apps/frontend_app_ecommerce/views.py
@@ -93,4 +93,11 @@ class UserOrdersView(APIView):
         for order_set in order_data:
             output_orders.extend(order_set['results'])
 
-        return Response(sorted(output_orders, key=lambda item: date_conv(item["date_placed"]), reverse=True))
+        output = {
+            "count": request.query_params['page_size'],  # This suppresses the ecomm mfe Order History Pagination ctrl
+            "next": None,
+            "previous": None,
+            "results": sorted(output_orders, key=lambda item: date_conv(item["date_placed"]), reverse=True)
+        }
+
+        return Response(output)

--- a/commerce_coordinator/settings/devstack.py
+++ b/commerce_coordinator/settings/devstack.py
@@ -7,8 +7,8 @@ DATABASES = {
         'NAME': os.environ.get('DB_NAME', 'commerce_coordinator'),
         'USER': os.environ.get('DB_USER', 'root'),
         'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', 'commerce_coordinator.db'),
-        'PORT': os.environ.get('DB_PORT', 3306),
+        'HOST': os.environ.get('DB_HOST', '127.0.0.1'),
+        'PORT': os.environ.get('DB_PORT', 3406),
         'ATOMIC_REQUESTS': False,
         'CONN_MAX_AGE': 60,
     }

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -78,11 +78,11 @@ BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = os.environ.get(
 )
 BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get(
     'BACKEND_SERVICE_EDX_OAUTH2_KEY',
-    'commerce-coordinator-backend-service-key'
+    'commerce_coordinator-backend-service-key'
 )
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get(
     'BACKEND_SERVICE_EDX_OAUTH2_SECRET',
-    'commerce-coordinator-backend-service-secret'
+    'commerce_coordinator-backend-service-secret'
 )
 
 JWT_AUTH.update({


### PR DESCRIPTION
- Added settings for future formatting
- Updating local settings to use the provisioned key name, even though it fails the standard format by having an underscore
- Updating devstack to not use sqlite
