### PR TITLE
feat: add authentication for commercetools views

### DIFF
--- a/commerce_coordinator/apps/commercetools/authentication.py
+++ b/commerce_coordinator/apps/commercetools/authentication.py
@@ -1,0 +1,41 @@
+"""
+Django REST Framework authentication classes.
+"""
+
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from rest_framework_jwt.compat import smart_str
+
+
+class JwtBearerAuthentication(JwtAuthentication):
+    """
+    Class to ignore JWT_AUTH_HEADER_PREFIX, using ``Bearer`` instead.
+
+    The Open edX platform defaults to an authorization header like:
+
+        Authorization: JWT <jwt-token>
+
+    We do this by setting JWT_AUTH_HEADER_PREFIX to ``Bearer``.
+
+    However, most OAuth2 implementations use an authorization header like:
+
+        Authorization: Bearer <jwt-token>
+
+    This class allows us to default to the former, but selectively choose
+    Django REST Framework views where we can ignore JWT_AUTH_HEADER_PREFIX and
+    expect ``Bearer`` instead for the latter, by adding this class as one of
+    the ``authentication_classes`` of the view.
+
+    See: https://styria-digital.github.io/django-rest-framework-jwt/#jwt_auth_header_prefix
+    See: https://github.com/Styria-Digital/django-rest-framework-jwt/blob/4e8550e15902399df277aac97e6f300a0610697f/CHANGELOG.md?plain=1#L356  # pylint: disable=line-too-long # noqa: E501
+    """
+
+    @classmethod
+    def prefixes_match(cls, prefix):
+        """
+        Check to see if prefix is ``bearer`` (instead of JWT_AUTH_HEADER_PREFIX).
+
+        Overrides the following implementation:
+
+        https://github.com/Styria-Digital/django-rest-framework-jwt/blob/4e8550e15902399df277aac97e6f300a0610697f/src/rest_framework_jwt/authentication.py#L117
+        """
+        return smart_str(prefix.lower()) == 'bearer'

--- a/commerce_coordinator/apps/commercetools/tests/test_authentication.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_authentication.py
@@ -1,0 +1,78 @@
+"""Tests for the commercetools views"""
+
+from django.conf import settings
+from django.test import RequestFactory
+from rest_framework.test import APITestCase
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+
+from commerce_coordinator.apps.core.models import User
+
+from ..authentication import JwtBearerAuthentication
+
+
+class JwtBearerAuthenticationTests(APITestCase):
+    "Tests for JwtBearerAuthentication class."
+
+    uut = JwtBearerAuthentication
+
+    test_username = 'username'
+    test_password = 'password'
+
+    def setUp(self):
+        """Create test user and token."""
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username=self.test_username,
+            password=self.test_password
+        )
+        self.payload = JSONWebTokenAuthentication.jwt_create_payload(self.user)
+        self.token = JSONWebTokenAuthentication.jwt_encode_payload(self.payload)
+
+    def test_authenticated_with_bearer_prefix(self):
+        """
+        Check user with valid credentials passed using Bearer auth header prefix
+        is authenticated.
+        """
+
+        # Assume:
+        assert settings.JWT_AUTH['JWT_AUTH_HEADER_PREFIX'] == 'JWT'
+
+        # Build request:
+        request = self.factory.post(
+            '/test',
+            headers={'Authorization': f'Bearer {self.token}'}
+        )
+
+        # Authenticate:
+        result = self.uut().authenticate(request)
+        # See base implementation:
+        # https://github.com/Styria-Digital/django-rest-framework-jwt/blob/4e8550e15902399df277aac97e6f300a0610697f/src/rest_framework_jwt/authentication.py#L60
+
+        # A return of a user, token tuple means the user is authenticated.
+        assert result == (self.user, self.token)
+
+    def test_not_authenticated_with_jwt_prefix(self):
+        """
+        Check user with valid credentials passed using JWT auth header prefix
+        is not authenticated.
+
+        Why: The point of this class / the unit under test is to force the
+        equivalent of overriding JWT_AUTH_HEADER_PREFIX to ``Bearer``.
+        """
+
+        # Assume:
+        assert settings.JWT_AUTH['JWT_AUTH_HEADER_PREFIX'] == 'JWT'
+
+        # Build request:
+        request = self.factory.post(
+            '/test',
+            headers={'Authorization': f'JWT {self.token}'}
+        )
+
+        # Authenticate:
+        result = self.uut().authenticate(request)
+        # See base implementation:
+        # https://github.com/Styria-Digital/django-rest-framework-jwt/blob/4e8550e15902399df277aac97e6f300a0610697f/src/rest_framework_jwt/authentication.py#L60
+
+        # A return of None means the user is not authenticated.
+        assert result is None

--- a/commerce_coordinator/apps/commercetools/tests/test_views.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_views.py
@@ -174,6 +174,18 @@ class OrderFulfillViewTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_unauthorized_user(self, mock_customer, mock_order, mock_signal):
+        """Check unauthorized user is forbidden."""
+
+        # Login
+        self.client.login(username=self.test_user_username, password=self.test_password)
+
+        # Send request
+        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE, format='json')
+
+        # Check 403 Forbidden
+        self.assertEqual(response.status_code, 403)
+
 
 @ddt.ddt
 class OrderSanctionedViewTests(APITestCase):
@@ -443,3 +455,15 @@ class OrderReturnedViewTests(APITestCase):
 
         # Check 200 OK
         self.assertEqual(response.status_code, 200)
+
+    def test_unauthorized_user(self):
+        """Check unauthorized user is forbidden."""
+
+        # Login
+        self.client.login(username=self.test_user_username, password=self.test_password)
+
+        # Send request
+        response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_SANCTIONED_MESSAGE, format='json')
+
+        # Check 403 Forbidden
+        self.assertEqual(response.status_code, 403)

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -5,6 +5,7 @@ import logging
 
 from commercetools import CommercetoolsError
 from rest_framework import status
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -13,6 +14,7 @@ from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUK
 from commerce_coordinator.apps.commercetools.serializers import OrderFulfillViewInputSerializer
 from commerce_coordinator.apps.commercetools.signals import fulfill_order_placed_signal
 
+from .authentication import JwtBearerAuthentication
 from .catalog_info.edx_utils import (
     get_edx_is_sanctioned,
     get_edx_items,
@@ -38,6 +40,9 @@ SOURCE_SYSTEM = 'commercetools'
 # noinspection DuplicatedCode
 class OrderFulfillView(APIView):
     """Order Fulfillment View"""
+
+    authentication_classes = [JwtBearerAuthentication, SessionAuthentication]
+    permission_classes = [IsAdminUser]
 
     def post(self, request):
         """Receive a message from commerce tools forwarded by aws event bridge"""
@@ -113,6 +118,8 @@ class OrderFulfillView(APIView):
 # noinspection DuplicatedCode
 class OrderSanctionedView(APIView):
     """View to sanction an order and deactivate the lms user"""
+
+    authentication_classes = [JwtBearerAuthentication, SessionAuthentication]
     permission_classes = [IsAdminUser]
 
     def post(self, request):

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -6,6 +6,7 @@ ALLOWED_HOSTS += (
     # Built-in alias to reach the host machine running Docker Desktop from inside a container:
     'host.docker.internal',
     'localhost',
+    '.ngrok-free.app',
 )
 
 INSTALLED_APPS += (

--- a/docs/commerce_coordinator.apps.commercetools.rst
+++ b/docs/commerce_coordinator.apps.commercetools.rst
@@ -20,6 +20,14 @@ commerce\_coordinator.apps.commercetools.apps module
    :undoc-members:
    :show-inheritance:
 
+commerce\_coordinator.apps.commercetools.authentication module
+--------------------------------------------------------------
+
+.. automodule:: commerce_coordinator.apps.commercetools.authentication
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 commerce\_coordinator.apps.commercetools.clients module
 -------------------------------------------------------
 

--- a/docs/commerce_coordinator.apps.ecommerce.rst
+++ b/docs/commerce_coordinator.apps.ecommerce.rst
@@ -38,7 +38,7 @@ commerce\_coordinator.apps.ecommerce.clients module
    :show-inheritance:
 
 commerce\_coordinator.apps.ecommerce.constants module
-------------------------------------------------------
+-----------------------------------------------------
 
 .. automodule:: commerce_coordinator.apps.ecommerce.constants
    :members:

--- a/docs/how_tos.rst
+++ b/docs/how_tos.rst
@@ -1,0 +1,12 @@
+How-Tos
+#######
+
+The following `How-Tos` are relatively long-term step-by-step instructions in using a feature/component/etc.
+
+.. _How-Tos: https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0019-bp-developer-documentation.html#how-tos
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   how_tos/*

--- a/docs/how_tos/using_ngrok.rst
+++ b/docs/how_tos/using_ngrok.rst
@@ -1,0 +1,36 @@
+Using Ngrok
+###########
+
+Commerce Coordinator was built to connect Open edX and non-Open-edX services.
+Non-Open-edX services may be cloud-hosted, and not reside on a developer's
+local machine.
+
+This How To walks through using a service called `Ngrok`_ to generate URLs for
+a cloud service to connect to an Open edX service located on a developer's
+local machine for testing and development purposes.
+
+.. _Ngrok: https://ngrok.com
+
+#. Start LMS in devstack at http://localhost:18000.
+
+#. Start Coordinator on your local at http://localhost:8140.
+
+#. Create an Ngrok account and get an authtoken at
+   https://dashboard.ngrok.com/get-started/your-authtoken
+
+#. Coordinator's repo has file ngrok.yml. Run from the same directory as
+   ngrok.yml. Substitute your Ngrok authtoken from step above.
+
+    .. code-block::
+
+        brew install ngrok/ngrok/ngrok
+        ngrok config add-authtoken --config ngrok.yml <AUTHTOKEN>
+        ngrok start --config ngrok.yml --all
+
+#. You should see the urls for Coordinator and LMS Ngrok appear in your
+   console, similar to:
+
+    .. code-block::
+
+        https://032f-2601-184-497f-983e-20b0-ed78-ed2f-6f.ngrok-free.app → http://localhost:8140
+        https://852e-2601-184-497f-983e-20b0-ed78-ed2f-6f.ngrok-free.app → http://localhost:18000

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Contents:
    modules
    changelog
    decisions
+   how_tos
    features
 
 

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,0 +1,8 @@
+tunnels:
+    coordinator:
+        proto: http
+        addr: 8140
+    lms:
+        proto: http
+        addr: 18000
+version: 2


### PR DESCRIPTION
## Description

The views for the Commercetools app are implemented to allow an external service configured with a Commercetools Subscription, like AWS EventBridge, to send Commercetools Messages to Coordinator.

AWS EventBridge supports retrieving a token from an OAuth2 service. In this case, we have instructed it to get a token from LMS. However, AWS EventBridge will expect that the consuming API Destination perform authorization by expecting a header like:

    Authorization: Bearer <token>

Coordinator is configured to expect headers like:

    Authorization: JWT <token>

Because this is what other MFEs use.

This commit adds class `JwtBearerAuthentication` to allow Coordinator to expect the new header format, as well as enforce that authentication method on existing views in Coordinator's Commercetools app.

## Additional Information

* Jira: [SONIC-268](https://2u-internal.atlassian.net/browse/SONIC-268) Set up authentication between EventBridge & Coordinator
* Reapplies / un-reverts: https://github.com/edx/commerce-coordinator/pull/174
* Follow on to: https://github.com/edx/commerce-coordinator/pull/166