### PR TITLE
feat: CT refund transaction from Stripe dashboard refund

### DIFF
--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -4,7 +4,7 @@ Commercetools signals and receivers.
 import logging
 
 from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
-from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion
+from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion, refund_from_stripe_task
 from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
 
 logger = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ fulfill_order_placed_signal = CoordinatorSignal()
 @log_receiver(logger)
 def fulfill_order_completed_send_line_item_state(**kwargs):
     """
-    Fulfill the order placed in Titan with a Celery task to LMS to enroll a user in a single course.
+    Update the line item state of the order placed in Commercetools based on LMS enrollment
     """
 
     is_fulfilled = kwargs['is_fulfilled']
@@ -35,3 +35,15 @@ def fulfill_order_completed_send_line_item_state(**kwargs):
     )
 
     return result
+
+@log_receiver(logger)
+def refund_from_stripe(**kwargs):
+    """
+    Create a refund transaction in Commercetools based on a refund created from the Stripe dashboard
+    """
+    #import pdb; pdb.set_trace()
+    async_result = refund_from_stripe_task.delay(
+        payment_intent_id=kwargs['payment_intent_id'],
+        stripe_refund=kwargs['stripe_refund'],
+    )
+    return async_result.id

--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -4,7 +4,10 @@ Commercetools signals and receivers.
 import logging
 
 from commerce_coordinator.apps.commercetools.catalog_info.constants import TwoUKeys
-from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion, refund_from_stripe_task
+from commerce_coordinator.apps.commercetools.tasks import (
+    refund_from_stripe_task,
+    update_line_item_state_on_fulfillment_completion
+)
 from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal, log_receiver
 
 logger = logging.getLogger(__name__)
@@ -36,12 +39,12 @@ def fulfill_order_completed_send_line_item_state(**kwargs):
 
     return result
 
+
 @log_receiver(logger)
 def refund_from_stripe(**kwargs):
     """
     Create a refund transaction in Commercetools based on a refund created from the Stripe dashboard
     """
-    #import pdb; pdb.set_trace()
     async_result = refund_from_stripe_task.delay(
         payment_intent_id=kwargs['payment_intent_id'],
         stripe_refund=kwargs['stripe_refund'],

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -259,40 +259,44 @@ def fulfill_order_returned_signal_task(
         )
 
         if 'refund_response' in result and result['refund_response']:
-            logger.debug(f'[CT-{tag}] payment intent %s refunded', payment_intent_id)
-            segment_event_properties = _prepare_segment_event_properties(order, return_line_item_return_id)
+            if result['refund_response'] == 'charge_already_refunded':
+                logger.debug(f'[CT-{tag}] payment intent %s already has refund transaction, sending Zendesk email', payment_intent_id)
+                send_refund_notification(customer, order_id)
+            else:
+                logger.debug(f'[CT-{tag}] payment intent %s refunded', payment_intent_id)
+                segment_event_properties = _prepare_segment_event_properties(order, return_line_item_return_id)
 
-            for line_item in get_edx_items(order):
-                course_run = get_edx_product_course_run_key(line_item)
-                # TODO: Remove LMS Enrollment
-                logger.debug(
-                    f'[CT-{tag}] calling lms to unenroll user %s in %s',
-                    lms_user_name, course_run
-                )
+                for line_item in get_edx_items(order):
+                    course_run = get_edx_product_course_run_key(line_item)
+                    # TODO: Remove LMS Enrollment
+                    logger.debug(
+                        f'[CT-{tag}] calling lms to unenroll user %s in %s',
+                        lms_user_name, course_run
+                    )
 
-                product = {
-                    'product_id': line_item.product_key,
-                    'sku': line_item.variant.sku if hasattr(line_item.variant, 'sku') else None,
-                    'name': line_item.name['en-US'],
-                    'price': _cents_to_dollars(line_item.price.value),
-                    'quantity': line_item.quantity,
-                    'category': _get_line_item_attribute(line_item, 'primary-subject-area'),
-                    'image_url': line_item.variant.images[0].url if line_item.variant.images else None,
-                    'brand': _get_line_item_attribute(line_item, 'brand-text'),
-                    'url': _get_line_item_attribute(line_item, 'url-course'),
-                    'lob': 'edX',  # TODO: Decision was made to hardcode this value for phase 1.
-                    'product_type': line_item.product_type.obj.name
-                    if hasattr(line_item.product_type.obj, 'name') else None
-                }
-                segment_event_properties['products'].append(product)
+                    product = {
+                        'product_id': line_item.product_key,
+                        'sku': line_item.variant.sku if hasattr(line_item.variant, 'sku') else None,
+                        'name': line_item.name['en-US'],
+                        'price': _cents_to_dollars(line_item.price.value),
+                        'quantity': line_item.quantity,
+                        'category': _get_line_item_attribute(line_item, 'primary-subject-area'),
+                        'image_url': line_item.variant.images[0].url if line_item.variant.images else None,
+                        'brand': _get_line_item_attribute(line_item, 'brand-text'),
+                        'url': _get_line_item_attribute(line_item, 'url-course'),
+                        'lob': 'edX',  # TODO: Decision was made to hardcode this value for phase 1.
+                        'product_type': line_item.product_type.obj.name
+                        if hasattr(line_item.product_type.obj, 'name') else None
+                    }
+                    segment_event_properties['products'].append(product)
 
-            if segment_event_properties['products']:  # pragma no cover
-                # Emitting the 'Order Refunded' Segment event upon successfully processing a refund.
-                track(
-                    lms_user_id=lms_user_id,
-                    event='Order Refunded',
-                    properties=segment_event_properties
-                )
+                if segment_event_properties['products']:  # pragma no cover
+                    # Emitting the 'Order Refunded' Segment event upon successfully processing a refund.
+                    track(
+                        lms_user_id=lms_user_id,
+                        event='Order Refunded',
+                        properties=segment_event_properties
+                    )
         else:  # pragma no cover
             logger.debug(f'[CT-{tag}] payment intent %s not refunded', payment_intent_id)
             return send_refund_notification(customer, order_id)

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -260,7 +260,8 @@ def fulfill_order_returned_signal_task(
 
         if 'refund_response' in result and result['refund_response']:
             if result['refund_response'] == 'charge_already_refunded':
-                logger.debug(f'[CT-{tag}] payment intent %s already has refund transaction, sending Zendesk email', payment_intent_id)
+                logger.debug(f'[CT-{tag}] payment intent %s already has refund transaction, '
+                             f'sending Zendesk email', payment_intent_id)
                 send_refund_notification(customer, order_id)
             else:
                 logger.debug(f'[CT-{tag}] payment intent %s refunded', payment_intent_id)

--- a/commerce_coordinator/apps/commercetools/tasks.py
+++ b/commerce_coordinator/apps/commercetools/tasks.py
@@ -2,18 +2,19 @@
 Commercetools tasks
 """
 
-import stripe
-from django.conf import settings
-from celery import shared_task
 import logging
 
+import stripe
+from celery import shared_task
 from commercetools import CommercetoolsError
+from django.conf import settings
 
 from .clients import CommercetoolsAPIClient
 
 logger = logging.getLogger(__name__)
 
 stripe.api_key = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['secret_key']
+
 
 def update_line_item_state_on_fulfillment_completion(
     order_id,
@@ -52,7 +53,6 @@ def refund_from_stripe_task(
     Celery task for a refund registered in Stripe dashboard and need to create
     refund payment transaction record via Commercetools API.
     """
-    #import pdb; pdb.set_trace()
     # Celery serializes stripe_refund to a dict, so we need to explictly convert it back to a Refund object
     stripe_refund = stripe.Refund.construct_from(stripe_refund, stripe.api_key)
     client = CommercetoolsAPIClient()
@@ -65,6 +65,7 @@ def refund_from_stripe_task(
         )
         return updated_payment
     except CommercetoolsError as err:
-        logger.error(f"Unable to create refund transaction for payment [ {payment.id} ] on Stripe refund {stripe_refund.id} "
+        logger.error(f"Unable to create refund transaction for payment [ {payment.id} ] "
+                     f"on Stripe refund {stripe_refund.id} "
                      f"with error {err.errors} and correlation id {err.correlation_id}")
         return None

--- a/commerce_coordinator/apps/commercetools/tasks.py
+++ b/commerce_coordinator/apps/commercetools/tasks.py
@@ -2,6 +2,9 @@
 Commercetools tasks
 """
 
+import stripe
+from django.conf import settings
+from celery import shared_task
 import logging
 
 from commercetools import CommercetoolsError
@@ -10,6 +13,7 @@ from .clients import CommercetoolsAPIClient
 
 logger = logging.getLogger(__name__)
 
+stripe.api_key = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['secret_key']
 
 def update_line_item_state_on_fulfillment_completion(
     order_id,
@@ -36,4 +40,31 @@ def update_line_item_state_on_fulfillment_completion(
     except CommercetoolsError as err:
         logger.error(f"Unable to update line item [ {line_item_id} ] state on fulfillment "
                      f"result with error {err.errors} and correlation id {err.correlation_id}")
+        return None
+
+
+@shared_task(autoretry_for=(CommercetoolsError,), retry_kwargs={'max_retries': 5, 'countdown': 3})
+def refund_from_stripe_task(
+    payment_intent_id,
+    stripe_refund
+):
+    """
+    Celery task for a refund registered in Stripe dashboard and need to create
+    refund payment transaction record via Commercetools API.
+    """
+    #import pdb; pdb.set_trace()
+    # Celery serializes stripe_refund to a dict, so we need to explictly convert it back to a Refund object
+    stripe_refund = stripe.Refund.construct_from(stripe_refund, stripe.api_key)
+    client = CommercetoolsAPIClient()
+    try:
+        payment = client.get_payment_by_key(payment_intent_id)
+        updated_payment = client.create_return_payment_transaction(
+            payment_id=payment.id,
+            payment_version=payment.version,
+            stripe_refund=stripe_refund
+        )
+        return updated_payment
+    except CommercetoolsError as err:
+        logger.error(f"Unable to create refund transaction for payment [ {payment.id} ] on Stripe refund {stripe_refund.id} "
+                     f"with error {err.errors} and correlation id {err.correlation_id}")
         return None

--- a/commerce_coordinator/apps/commercetools/tests/constants.py
+++ b/commerce_coordinator/apps/commercetools/tests/constants.py
@@ -81,6 +81,33 @@ EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD = {
     'to_state_key': TwoUKeys.SUCCESS_FULFILMENT_STATE
 }
 
+EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD = {
+    'payment_intent_id': 'pi_3PNWMsH4caH7G0X109NekCG5',
+    'stripe_refund': {
+        'id': "re_1Nispe2eZvKYlo2Cd31jOCgZ",
+        'amount': 1000,
+        'charge': "ch_1NirD82eZvKYlo2CIvbtLWuY",
+        'created': 1692942318,
+        'currency': "usd",
+        'payment_intent': "pi_3PNWMsH4caH7G0X109NekCG5",
+        'status': "succeeded",
+    }
+}
+
+EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD = {
+    'payment_id': 'f988e0c5-ea44-4111-a7f2-39ecf6af9840',
+    'payment_version':1,
+    'stripe_refund': {
+        'id': "re_1Nispe2eZvKYlo2Cd31jOCgZ",
+        'amount': 1000,
+        'charge': "ch_1NirD82eZvKYlo2CIvbtLWuY",
+        'created': 1692942318,
+        'currency': "usd",
+        'payment_intent': "pi_3PNWMsH4caH7G0X109NekCG5",
+        'status': "succeeded",
+    }
+}
+
 EXAMPLE_COMMERCETOOLS_ORDER_SANCTIONED_MESSAGE = {
     'version': '0',
     'id': 'aaaaaaaa-8888-00ee-aaaa-aaaaaaaaaaaa',

--- a/commerce_coordinator/apps/commercetools/tests/constants.py
+++ b/commerce_coordinator/apps/commercetools/tests/constants.py
@@ -96,7 +96,7 @@ EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD = {
 
 EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD = {
     'payment_id': 'f988e0c5-ea44-4111-a7f2-39ecf6af9840',
-    'payment_version':1,
+    'payment_version': 1,
     'stripe_refund': {
         'id': "re_1Nispe2eZvKYlo2Cd31jOCgZ",
         'amount': 1000,

--- a/commerce_coordinator/apps/commercetools/tests/test_signals.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_signals.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 
 from django.test import override_settings
 
-from commerce_coordinator.apps.core.tests.utils import CoordinatorSignalReceiverTestCase
 from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD
+from commerce_coordinator.apps.core.tests.utils import CoordinatorSignalReceiverTestCase
 
 # Log using module name.
 logger = logging.getLogger(__name__)

--- a/commerce_coordinator/apps/commercetools/tests/test_signals.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_signals.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from django.test import override_settings
 
 from commerce_coordinator.apps.core.tests.utils import CoordinatorSignalReceiverTestCase
+from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD
 
 # Log using module name.
 logger = logging.getLogger(__name__)
@@ -47,3 +48,31 @@ class FulfillOrderCompletedSendLineItemStateTest(CoordinatorSignalReceiverTestCa
         task_mock_parameters['from_state_id'] = task_mock_parameters.pop('line_item_state_id')
         logger.info('logs.output: %s', logs.output)
         mock_task.assert_called_with(**task_mock_parameters, to_state_key='2u-fulfillment-failure-state')
+
+
+@override_settings(
+    CC_SIGNALS={
+        'commerce_coordinator.apps.core.tests.utils.example_signal': [
+            'commerce_coordinator.apps.commercetools.signals.refund_from_stripe',
+        ],
+    }
+)
+@patch('commerce_coordinator.apps.commercetools.signals.refund_from_stripe_task')
+class RefundFromStripeTest(CoordinatorSignalReceiverTestCase):
+    """ Stripe Dashboard Refund Placed, Create Return CT Transaction Signal Tester"""
+    mock_parameters = EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD
+
+    def test_correct_arguments_passed(self, mock_task):
+        _, logs = self.fire_signal()
+        logger.info('logs.output: %s', logs.output)
+        mock_task.delay.assert_called_once_with(
+            payment_intent_id=self.mock_parameters['payment_intent_id'],
+            stripe_refund=self.mock_parameters['stripe_refund']
+        )
+
+    def test_correct_response_returned(self, mock_task):
+        mock_task.delay.return_value.id = 'bogus_task_id'
+        result, _ = self.fire_signal()
+        logger.info('result: %s', result)
+        self.assertEqual(result[0][1], 'bogus_task_id',
+                         'Check reciever result is same as return from task')

--- a/commerce_coordinator/apps/commercetools/tests/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_tasks.py
@@ -3,13 +3,15 @@ Commercetools app Task Tests
 """
 
 import logging
+import stripe
 from unittest.mock import patch
 
 from commercetools import CommercetoolsError
 from django.test import TestCase
 
-from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion
-from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD
+from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion, refund_from_stripe_task
+from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD, EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD,EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD
+from commerce_coordinator.apps.commercetools.tests.conftest import gen_payment
 from commerce_coordinator.apps.core.models import User
 
 # Log using module name.
@@ -18,7 +20,8 @@ logger = logging.getLogger(__name__)
 # Define unit under test.
 # Note: if the UUT is part of the class as an ivar, it trims off arg0 as 'self' and
 #       claims too many args supplied
-uut = update_line_item_state_on_fulfillment_completion
+fulfillment_uut = update_line_item_state_on_fulfillment_completion
+returned_uut = refund_from_stripe_task
 
 
 @patch('commerce_coordinator.apps.commercetools.tasks.CommercetoolsAPIClient')
@@ -45,7 +48,7 @@ class UpdateLineItemStateOnFulfillmentCompletionTaskTest(TestCase):
         Check calling uut with mock_parameters yields call to client with
         expected_data.
         '''
-        _ = uut(*self.unpack_for_uut(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD))
+        _ = fulfillment_uut(*self.unpack_for_uut(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD))
         logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
         mock_client().update_line_item_transition_state_on_fulfillment.assert_called_once_with(
             *list(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD.values())
@@ -64,7 +67,7 @@ class UpdateLineItemStateOnFulfillmentCompletionTaskTest(TestCase):
             correlation_id="123456"
         )
 
-        result = uut(*self.unpack_for_uut(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD))
+        result = fulfillment_uut(*self.unpack_for_uut(EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD))
 
         mock_logger.error.assert_called_once_with(
             f"Unable to update line item [ {EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD['line_item_id']} ] "
@@ -72,3 +75,66 @@ class UpdateLineItemStateOnFulfillmentCompletionTaskTest(TestCase):
         )
 
         assert result is None
+
+
+@patch('commerce_coordinator.apps.commercetools.tasks.CommercetoolsAPIClient')
+class ReturnedOrderfromStripeTaskTest(TestCase):
+    """ Returned Order From Stripe Task Test """
+
+    @staticmethod
+    def unpack_for_uut(values):
+        """ Unpack the dictionary in the order required for the UUT """
+        return (
+            values['payment_intent_id'],
+            values['stripe_refund'],
+        )
+
+    def setUp(self):
+        User.objects.create(username='test-user', lms_user_id=4)
+
+    def test_correct_arguments_passed(self, mock_client):
+        '''
+        Check calling uut with mock_parameters yields call to client with
+        expected_data.
+        '''
+        mock_payment = gen_payment()
+        mock_payment.id = 'f988e0c5-ea44-4111-a7f2-39ecf6af9840'
+        mock_client.return_value.get_payment_by_key.return_value = mock_payment
+
+        mock_stripe_refund = stripe.Refund()
+        stripe_refund_json = EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD['stripe_refund']
+        mock_stripe_refund.update(stripe_refund_json)
+
+        _ = returned_uut(*self.unpack_for_uut(EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD))
+        logger.info('mock_client().mock_calls: %s', mock_client().mock_calls)
+
+        mock_client().create_return_payment_transaction.assert_called_once_with(
+            payment_id=mock_payment.id,
+            payment_version=mock_payment.version,
+            stripe_refund=mock_stripe_refund
+        )
+
+    @patch('commerce_coordinator.apps.commercetools.tasks.logger')
+    def test_exception_handling(self, mock_logger, mock_client):
+        '''
+        Check if an error in the client results in a logged error
+        and None returned.
+        '''
+        mock_payment = gen_payment()
+        mock_payment.id = 'f988e0c5-ea44-4111-a7f2-39ecf6af9840'
+        mock_client.return_value.get_payment_by_key.return_value = mock_payment
+        mock_client().create_return_payment_transaction.side_effect = CommercetoolsError(
+            message="Could not create return transaction",
+            errors="Some error message",
+            response={},
+            correlation_id="123456"
+        )
+
+        returned_uut(*self.unpack_for_uut(EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD))
+
+        mock_logger.error.assert_called_once_with(
+            f"Unable to create refund transaction for payment [ {EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD['payment_id']} ] "
+            f"on Stripe refund {EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD['stripe_refund']['id']} "
+            f"with error Some error message and correlation id 123456"
+        )
+

--- a/commerce_coordinator/apps/commercetools/tests/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_tasks.py
@@ -3,15 +3,22 @@ Commercetools app Task Tests
 """
 
 import logging
-import stripe
 from unittest.mock import patch
 
+import stripe
 from commercetools import CommercetoolsError
 from django.test import TestCase
 
-from commerce_coordinator.apps.commercetools.tasks import update_line_item_state_on_fulfillment_completion, refund_from_stripe_task
-from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD, EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD,EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD
+from commerce_coordinator.apps.commercetools.tasks import (
+    refund_from_stripe_task,
+    update_line_item_state_on_fulfillment_completion
+)
 from commerce_coordinator.apps.commercetools.tests.conftest import gen_payment
+from commerce_coordinator.apps.commercetools.tests.constants import (
+    EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD,
+    EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD,
+    EXAMPLE_UPDATE_LINE_ITEM_SIGNAL_PAYLOAD
+)
 from commerce_coordinator.apps.core.models import User
 
 # Log using module name.
@@ -133,8 +140,7 @@ class ReturnedOrderfromStripeTaskTest(TestCase):
         returned_uut(*self.unpack_for_uut(EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD))
 
         mock_logger.error.assert_called_once_with(
-            f"Unable to create refund transaction for payment [ {EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD['payment_id']} ] "
+            f"Unable to create refund transaction for payment [ {mock_payment.id} ] "
             f"on Stripe refund {EXAMPLE_RETURNED_ORDER_STRIPE_CLIENT_PAYLOAD['stripe_refund']['id']} "
             f"with error Some error message and correlation id 123456"
         )
-

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 
 from commerce_coordinator.apps.commercetools.authentication import JwtBearerAuthentication
 from commerce_coordinator.apps.commercetools.constants import SOURCE_SYSTEM
+from commerce_coordinator.apps.core.views import SingleInvocationAPIView
 from commerce_coordinator.apps.commercetools.serializers import (
     OrderLineItemMessageInputSerializer,
     OrderMessageInputSerializer
@@ -48,74 +49,6 @@ from .serializers import OrderMessageInputSerializer, OrderReturnedViewMessageIn
 # )
 
 logger = logging.getLogger(__name__)
-
-
-NOTIFICATION_CACHE_TTL_SECS = 60 * 10  # 10 Mins
-
-
-class SingleInvocationAPIView(APIView):
-    """APIView that can mark itself as running or not running within TieredCache"""
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.meta_id = None
-        self.meta_view = None
-        self.meta_should_mark_not_running = True
-
-    @staticmethod
-    def _view_cache_key(view: str, identifier: str) -> str:
-        """Get cache key for view and identifier"""
-        return safe_key(key=f"{view}_{identifier}", key_prefix="ct_sub_msg_invo", version="1")
-
-    def mark_running(self, view: str, identifier: str, tf=True):
-        """Mark view as running or not running"""
-        self.set_view(view)
-        self.set_identifier(identifier)
-        key = SingleInvocationAPIView._view_cache_key(view, identifier)
-
-        if TieredCache.get_cached_response(key).is_found or not tf:
-            try:
-                TieredCache.delete_all_tiers(key)
-
-            # not all caches throw this but a few do.
-            except ValueError as _:  # pragma no cover
-                # No-Op, Key not found.
-                pass
-
-        if tf:
-            TieredCache.set_all_tiers(key, tf, NOTIFICATION_CACHE_TTL_SECS)
-
-    @staticmethod
-    def _is_running(view: str, identifier: str):
-        """Check if view is running"""
-        key = SingleInvocationAPIView._view_cache_key(view, identifier)
-        cache_value = TieredCache.get_cached_response(key)
-        if cache_value.is_found or cache_value.get_value_or_default(False):
-            logger.debug(f'[CT-{view}] Currently processing request for %s, ignoring invocation', identifier)
-            return True
-        return False
-
-    def set_view(self, view: str):
-        """Set the view to mark as running"""
-        self.meta_view = view
-
-    def set_identifier(self, identifier: str):
-        """Set the identifier to mark as running"""
-        self.meta_id = identifier
-
-    # Right now we DON'T want to mark the view as not running, unless error.
-    # def finalize_response(self, request, response, *args, **kwargs):
-    #     tag = self.meta_view
-    #     identifier = self.meta_id
-    #     if self.meta_should_mark_not_running:
-    #         SingleInvocationAPIView.mark_running(tag, identifier, False)
-    #     return super().finalize_response(request, response, *args, **kwargs)
-
-    def handle_exception(self, exc):
-        """Mark view as not running on exception"""
-        tag = self.meta_view
-        identifier = self.meta_id
-        self.mark_running(tag, identifier, False)
-        return super().handle_exception(exc)
 
 
 # noinspection DuplicatedCode

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -3,16 +3,13 @@ Views for the commercetools app
 """
 import logging
 
-from edx_django_utils.cache import TieredCache
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from commerce_coordinator.apps.commercetools.authentication import JwtBearerAuthentication
 from commerce_coordinator.apps.commercetools.constants import SOURCE_SYSTEM
-from commerce_coordinator.apps.core.views import SingleInvocationAPIView
 from commerce_coordinator.apps.commercetools.serializers import (
     OrderLineItemMessageInputSerializer,
     OrderMessageInputSerializer
@@ -22,7 +19,7 @@ from commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch impor
     fulfill_order_returned_signal,
     fulfill_order_sanctioned_message_signal
 )
-from commerce_coordinator.apps.core.memcache import safe_key
+from commerce_coordinator.apps.core.views import SingleInvocationAPIView
 
 from .authentication import JwtBearerAuthentication
 from .serializers import OrderMessageInputSerializer, OrderReturnedViewMessageInputSerializer

--- a/commerce_coordinator/apps/core/views.py
+++ b/commerce_coordinator/apps/core/views.py
@@ -3,17 +3,17 @@ import logging
 import uuid
 
 from django.conf import settings
-from edx_django_utils.cache import TieredCache
-from rest_framework.views import APIView
-from commerce_coordinator.apps.core.memcache import safe_key
 from django.contrib.auth import authenticate, get_user_model, login
 from django.db import DatabaseError, connection, transaction
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.views.generic import View
+from edx_django_utils.cache import TieredCache
 from edx_django_utils.monitoring import ignore_transaction
+from rest_framework.views import APIView
 
 from commerce_coordinator.apps.core.constants import Status
+from commerce_coordinator.apps.core.memcache import safe_key
 
 logger = logging.getLogger(__name__)
 User = get_user_model()

--- a/commerce_coordinator/apps/core/views.py
+++ b/commerce_coordinator/apps/core/views.py
@@ -3,6 +3,9 @@ import logging
 import uuid
 
 from django.conf import settings
+from edx_django_utils.cache import TieredCache
+from rest_framework.views import APIView
+from commerce_coordinator.apps.core.memcache import safe_key
 from django.contrib.auth import authenticate, get_user_model, login
 from django.db import DatabaseError, connection, transaction
 from django.http import Http404, JsonResponse
@@ -14,6 +17,7 @@ from commerce_coordinator.apps.core.constants import Status
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
+NOTIFICATION_CACHE_TTL_SECS = 60 * 10  # 10 Mins
 
 
 @transaction.non_atomic_requests
@@ -87,3 +91,68 @@ class AutoAuth(View):
         login(request, user)
 
         return redirect('/')
+
+
+class SingleInvocationAPIView(APIView):
+    """APIView that can mark itself as running or not running within TieredCache"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.meta_id = None
+        self.meta_view = None
+        self.meta_should_mark_not_running = True
+
+    @staticmethod
+    def _view_cache_key(view: str, identifier: str) -> str:
+        """Get cache key for view and identifier"""
+        return safe_key(key=f"{view}_{identifier}", key_prefix="ct_sub_msg_invo", version="1")
+
+    def mark_running(self, view: str, identifier: str, tf=True):
+        """Mark view as running or not running"""
+        self.set_view(view)
+        self.set_identifier(identifier)
+        key = SingleInvocationAPIView._view_cache_key(view, identifier)
+
+        if TieredCache.get_cached_response(key).is_found or not tf:
+            try:
+                TieredCache.delete_all_tiers(key)
+
+            # not all caches throw this but a few do.
+            except ValueError as _:  # pragma no cover
+                # No-Op, Key not found.
+                pass
+
+        if tf:
+            TieredCache.set_all_tiers(key, tf, NOTIFICATION_CACHE_TTL_SECS)
+
+    @staticmethod
+    def _is_running(view: str, identifier: str):
+        """Check if view is running"""
+        key = SingleInvocationAPIView._view_cache_key(view, identifier)
+        cache_value = TieredCache.get_cached_response(key)
+        if cache_value.is_found or cache_value.get_value_or_default(False):
+            logger.debug(f'[CT-{view}] Currently processing request for %s, ignoring invocation', identifier)
+            return True
+        return False
+
+    def set_view(self, view: str):
+        """Set the view to mark as running"""
+        self.meta_view = view
+
+    def set_identifier(self, identifier: str):
+        """Set the identifier to mark as running"""
+        self.meta_id = identifier
+
+    # Right now we DON'T want to mark the view as not running, unless error.
+    # def finalize_response(self, request, response, *args, **kwargs):
+    #     tag = self.meta_view
+    #     identifier = self.meta_id
+    #     if self.meta_should_mark_not_running:
+    #         SingleInvocationAPIView.mark_running(tag, identifier, False)
+    #     return super().finalize_response(request, response, *args, **kwargs)
+
+    def handle_exception(self, exc):
+        """Mark view as not running on exception"""
+        tag = self.meta_view
+        identifier = self.meta_id
+        self.mark_running(tag, identifier, False)
+        return super().handle_exception(exc)

--- a/commerce_coordinator/apps/rollout/utils.py
+++ b/commerce_coordinator/apps/rollout/utils.py
@@ -39,3 +39,12 @@ def is_commercetools_line_item_already_refunded(order: CTOrder, order_line_item_
     return_info_return_items = get_order_return_info_return_items(order)
 
     return len(list(filter(lambda item: item.line_item_id == order_line_item_id, return_info_return_items))) >= 1
+
+
+def is_commercetools_stripe_refund(source_system: str) -> bool:
+    """
+    Determine if a refund made in Stripe dashboard is for a commercetools order based on event metadata
+    """
+    if not source_system:
+        return False
+    return source_system == 'commercetools'

--- a/commerce_coordinator/apps/stripe/constants.py
+++ b/commerce_coordinator/apps/stripe/constants.py
@@ -8,6 +8,7 @@ class StripeEventType(str, Enum):
     """
     PAYMENT_SUCCESS = 'payment_intent.succeeded'
     PAYMENT_FAILED = 'payment_intent.payment_failed'
+    PAYMENT_REFUNDED = 'charge.refunded'
 
 
 class Currency(str, Enum):

--- a/commerce_coordinator/apps/stripe/signals.py
+++ b/commerce_coordinator/apps/stripe/signals.py
@@ -4,3 +4,4 @@ Stripe signals and receivers.
 from commerce_coordinator.apps.core.signal_helpers import CoordinatorSignal
 
 payment_processed_signal = CoordinatorSignal()
+payment_refunded_signal = CoordinatorSignal()

--- a/commerce_coordinator/apps/stripe/views.py
+++ b/commerce_coordinator/apps/stripe/views.py
@@ -6,14 +6,12 @@ import logging
 import stripe
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
-from edx_django_utils.cache import TieredCache
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from commerce_coordinator.apps.core.constants import PaymentState
-from commerce_coordinator.apps.core.memcache import safe_key
+from commerce_coordinator.apps.core.views import SingleInvocationAPIView
 from commerce_coordinator.apps.rollout.utils import is_commercetools_stripe_refund, is_legacy_order
 from commerce_coordinator.apps.stripe.constants import StripeEventType
 from commerce_coordinator.apps.stripe.exceptions import (
@@ -28,72 +26,6 @@ logger = logging.getLogger(__name__)
 stripe.api_key = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['secret_key']
 endpoint_secret = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['webhook_endpoint_secret']
 source_system_identifier = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['source_system_identifier']
-NOTIFICATION_CACHE_TTL_SECS = 60 * 10  # 10 Mins
-
-
-class SingleInvocationAPIView(APIView):
-    """APIView that can mark itself as running or not running within TieredCache"""
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.meta_id = None
-        self.meta_view = None
-        self.meta_should_mark_not_running = True
-
-    @staticmethod
-    def _view_cache_key(view: str, identifier: str) -> str:
-        """Get cache key for view and identifier"""
-        return safe_key(key=f"{view}_{identifier}", key_prefix="ct_sub_msg_invo", version="1")
-
-    def mark_running(self, view: str, identifier: str, tf=True):
-        """Mark view as running or not running"""
-        self.set_view(view)
-        self.set_identifier(identifier)
-        key = SingleInvocationAPIView._view_cache_key(view, identifier)
-
-        if TieredCache.get_cached_response(key).is_found or not tf:
-            try:
-                TieredCache.delete_all_tiers(key)
-
-            # not all caches throw this but a few do.
-            except ValueError as _:  # pragma no cover
-                # No-Op, Key not found.
-                pass
-
-        if tf:
-            TieredCache.set_all_tiers(key, tf, NOTIFICATION_CACHE_TTL_SECS)
-
-    @staticmethod
-    def _is_running(view: str, identifier: str):
-        """Check if view is running"""
-        key = SingleInvocationAPIView._view_cache_key(view, identifier)
-        cache_value = TieredCache.get_cached_response(key)
-        if cache_value.is_found or cache_value.get_value_or_default(False):
-            logger.debug(f'[CT-{view}] Currently processing request for %s, ignoring invocation', identifier)
-            return True
-        return False
-
-    def set_view(self, view: str):
-        """Set the view to mark as running"""
-        self.meta_view = view
-
-    def set_identifier(self, identifier: str):
-        """Set the identifier to mark as running"""
-        self.meta_id = identifier
-
-    # Right now we DON'T want to mark the view as not running, unless error.
-    # def finalize_response(self, request, response, *args, **kwargs):
-    #     tag = self.meta_view
-    #     identifier = self.meta_id
-    #     if self.meta_should_mark_not_running:
-    #         SingleInvocationAPIView.mark_running(tag, identifier, False)
-    #     return super().finalize_response(request, response, *args, **kwargs)
-
-    def handle_exception(self, exc):
-        """Mark view as not running on exception"""
-        tag = self.meta_view
-        identifier = self.meta_id
-        self.mark_running(tag, identifier, False)
-        return super().handle_exception(exc)
 
 
 class WebhookView(SingleInvocationAPIView):

--- a/commerce_coordinator/apps/stripe/views.py
+++ b/commerce_coordinator/apps/stripe/views.py
@@ -6,13 +6,15 @@ import logging
 import stripe
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
+from edx_django_utils.cache import TieredCache
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from commerce_coordinator.apps.core.constants import PaymentState
-from commerce_coordinator.apps.rollout.utils import is_legacy_order
+from commerce_coordinator.apps.core.memcache import safe_key
+from commerce_coordinator.apps.rollout.utils import is_commercetools_stripe_refund, is_legacy_order
 from commerce_coordinator.apps.stripe.constants import StripeEventType
 from commerce_coordinator.apps.stripe.exceptions import (
     InvalidPayloadAPIError,
@@ -26,9 +28,75 @@ logger = logging.getLogger(__name__)
 stripe.api_key = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['secret_key']
 endpoint_secret = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['webhook_endpoint_secret']
 source_system_identifier = settings.PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['source_system_identifier']
+NOTIFICATION_CACHE_TTL_SECS = 60 * 10  # 10 Mins
 
 
-class WebhookView(APIView):
+class SingleInvocationAPIView(APIView):
+    """APIView that can mark itself as running or not running within TieredCache"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.meta_id = None
+        self.meta_view = None
+        self.meta_should_mark_not_running = True
+
+    @staticmethod
+    def _view_cache_key(view: str, identifier: str) -> str:
+        """Get cache key for view and identifier"""
+        return safe_key(key=f"{view}_{identifier}", key_prefix="ct_sub_msg_invo", version="1")
+
+    def mark_running(self, view: str, identifier: str, tf=True):
+        """Mark view as running or not running"""
+        self.set_view(view)
+        self.set_identifier(identifier)
+        key = SingleInvocationAPIView._view_cache_key(view, identifier)
+
+        if TieredCache.get_cached_response(key).is_found or not tf:
+            try:
+                TieredCache.delete_all_tiers(key)
+
+            # not all caches throw this but a few do.
+            except ValueError as _:  # pragma no cover
+                # No-Op, Key not found.
+                pass
+
+        if tf:
+            TieredCache.set_all_tiers(key, tf, NOTIFICATION_CACHE_TTL_SECS)
+
+    @staticmethod
+    def _is_running(view: str, identifier: str):
+        """Check if view is running"""
+        key = SingleInvocationAPIView._view_cache_key(view, identifier)
+        cache_value = TieredCache.get_cached_response(key)
+        if cache_value.is_found or cache_value.get_value_or_default(False):
+            logger.debug(f'[CT-{view}] Currently processing request for %s, ignoring invocation', identifier)
+            return True
+        return False
+
+    def set_view(self, view: str):
+        """Set the view to mark as running"""
+        self.meta_view = view
+
+    def set_identifier(self, identifier: str):
+        """Set the identifier to mark as running"""
+        self.meta_id = identifier
+
+    # Right now we DON'T want to mark the view as not running, unless error.
+    # def finalize_response(self, request, response, *args, **kwargs):
+    #     tag = self.meta_view
+    #     identifier = self.meta_id
+    #     if self.meta_should_mark_not_running:
+    #         SingleInvocationAPIView.mark_running(tag, identifier, False)
+    #     return super().finalize_response(request, response, *args, **kwargs)
+
+    def handle_exception(self, exc):
+        """Mark view as not running on exception"""
+        tag = self.meta_view
+        identifier = self.meta_id
+        self.mark_running(tag, identifier, False)
+        return super().handle_exception(exc)
+
+
+class WebhookView(SingleInvocationAPIView):
     """
     Endpoint for Stripe webhook events. A 200 response should be returned as soon as possible
     since Stripe will retry the event if no response is received.
@@ -45,6 +113,7 @@ class WebhookView(APIView):
     @csrf_exempt
     def post(self, request):
         """Webhook entry point."""
+        tag = type(self).__name__
         payload = request.body
         sig_header = request.META['HTTP_STRIPE_SIGNATURE']
 
@@ -65,21 +134,30 @@ class WebhookView(APIView):
         elif event.type == StripeEventType.PAYMENT_FAILED:
             payment_state = PaymentState.FAILED.value
         elif event.type == StripeEventType.PAYMENT_REFUNDED:
-            payment_intent = event.data.object
-            event_source_system_identifier = payment_intent.metadata.get('source_system')
-            order_number = event.data.object.metadata.order_number
-            is_legacy_order_check = is_legacy_order(order_number)
-            source_systems_match = event_source_system_identifier == source_system_identifier
+            idempotency_key = event.get('request').get('idempotency_key')
+            if self._is_running(tag, idempotency_key):  # pragma no cover
+                self.meta_should_mark_not_running = False
+                return Response(status=status.HTTP_200_OK)
+            else:
+                self.mark_running(tag, idempotency_key)
 
-            if not is_legacy_order_check and source_systems_match:
-                payment_intent_id = event.data.object.payment_intent
-                refunds = event.data.object.refunds.data
+            event_object = event.data.object
+            order_number = event_object.metadata.order_number
+            is_legacy_order_check = is_legacy_order(order_number)
+            is_ct_order_check = is_commercetools_stripe_refund(event_object.metadata.get('source_system'))
+            payment_intent_id = event_object.payment_intent
+
+            if not is_legacy_order_check and is_ct_order_check:
+                event_source_system_identifier = event_object.metadata.get('source_system')
+                refunds = event_object.refunds.data
                 latest_refund = max(refunds, key=lambda refund: refund['created'])
 
                 logger.info(
-                    '[Stripe webhooks] refund event %s with payment intent ID [%s], source: [%s].',
+                    '[Stripe webhooks] refund event %s with payment intent ID [%s] '
+                    'and order number [%s], source: [%s].',
                     event.type,
                     payment_intent_id,
+                    order_number,
                     event_source_system_identifier,
                 )
 
@@ -87,6 +165,14 @@ class WebhookView(APIView):
                     sender=self.__class__,
                     payment_intent_id=payment_intent_id,
                     stripe_refund=latest_refund
+                )
+            else:
+                logger.info(
+                    '[Stripe webhooks] skipping refund event %s with payment intent ID [%s] '
+                    'and order number [%s], as it is not a Commercetools order.',
+                    event.type,
+                    payment_intent_id,
+                    order_number,
                 )
             return Response(status=status.HTTP_200_OK)
         else:


### PR DESCRIPTION
Updated the Stripe Webhookview to listen to the 'charge.refunded' event for if someone makes a refund directly from the Stripe dashboard. If it is a CT order, we create a refund transaction for it.

Ticket: https://2u-internal.atlassian.net/browse/SONIC-504
Functionality information ticket: https://2u-internal.atlassian.net/browse/SONIC-520
