### PR TITLE
fix: added check for duplicate refund transactions

### DIFF
--- a/commerce_coordinator/apps/commercetools/tests/conftest.py
+++ b/commerce_coordinator/apps/commercetools/tests/conftest.py
@@ -168,16 +168,38 @@ def gen_payment():
         amount_planned=4900,
         payment_method_info={},
         payment_status=PaymentState.PAID,
-        transactions=[gen_transaction()],
+        transactions=[gen_transaction(TransactionType.REFUND, 4900)],
         interface_interactions=[]
     )
 
 
-def gen_transaction() -> CTTransaction:
+def gen_payment_with_multiple_transactions(*args):
+    """
+    Generate a CTPayment object with multiple transaction records
+    """
+    transactions = []
+    for i in range(0, len(args), 2):
+        transaction = gen_transaction(args[i], args[i+1])
+        transactions.append(transaction)
+
+    return CTPayment(
+        id=uuid4_str(),
+        version=1,
+        created_at=datetime.now(),
+        last_modified_at=datetime.now(),
+        amount_planned=4900,
+        payment_method_info={},
+        payment_status=PaymentState.PAID,
+        transactions=transactions,
+        interface_interactions=[]
+    )
+
+
+def gen_transaction(transaction_type=None, amount=None) -> CTTransaction:
     return CTTransaction(
         id=uuid4_str(),
-        type=TransactionType.REFUND,
-        amount=4900,
+        type=transaction_type,
+        amount=amount,
         timestamp=datetime.now(),
         state=TransactionState.SUCCESS,
         interaction_id='ch_3P9RWsH4caH7G0X11toRGUJf'

--- a/commerce_coordinator/apps/commercetools/utils.py
+++ b/commerce_coordinator/apps/commercetools/utils.py
@@ -139,6 +139,21 @@ def has_refund_transaction(payment: Payment):
     return False
 
 
+def has_full_refund_transaction(payment: Payment):
+    """
+    Utility to determine is CT payment has an existing 'refund' transaction for the full
+    charge amount
+    """
+    # get charge transaction and get amount then check against refund.
+    charge_amount = 0
+    for transaction in payment.transactions:
+        if transaction.type == TransactionType.CHARGE:
+            charge_amount = transaction.amount
+        if transaction.type == TransactionType.REFUND and transaction.amount == charge_amount:  # pragma no cover
+            return True
+    return False
+
+
 def translate_stripe_refund_status_to_transaction_status(stripe_refund_status: str):
     """
     Utility to translate stripe's refund object's status attribute to a valid CT transaction state

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -327,6 +327,9 @@ CC_SIGNALS = {
     'commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch.fulfill_order_returned_signal': [
         'commerce_coordinator.apps.commercetools.sub_messages.signals_delayed.fulfill_order_returned_signal',
     ],
+    'commerce_coordinator.apps.stripe.signals.payment_refunded_signal': [
+        'commerce_coordinator.apps.commercetools.signals.refund_from_stripe',
+    ],
 }
 
 # Default timeouts for requests

--- a/commerce_coordinator/settings/test.py
+++ b/commerce_coordinator/settings/test.py
@@ -84,6 +84,9 @@ CC_SIGNALS = {
     'commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch.fulfill_order_returned_signal': [
         'commerce_coordinator.apps.commercetools.sub_messages.signals_delayed.fulfill_order_returned_signal',
     ],
+    'commerce_coordinator.apps.stripe.signals.payment_refunded_signal': [
+        'commerce_coordinator.apps.commercetools.signals.refund_from_stripe',
+    ],
 }
 
 COMMERCETOOLS_CONFIG = {


### PR DESCRIPTION
Fix following #234 and #240 which adds a check for any existing full refunds before creating a refund transaction when a `charge.refunded` stripe event fires, ensuring no duplicate refund transaction records on the Merchant Center. The signal configuration is also added to `base.py` again.
JIRA: https://2u-internal.atlassian.net/browse/SONIC-589
