### PR TITLE
fix: PayPal refund bug on prod

### DIFF
--- a/commerce_coordinator/apps/commercetools/clients.py
+++ b/commerce_coordinator/apps/commercetools/clients.py
@@ -531,7 +531,7 @@ class CommercetoolsAPIClient:
         try:
             logger.info(
                 f"[CommercetoolsAPIClient] - Creating refund transaction for payment with ID {payment_id} "
-                f"following successful refund {refund['id']} in PSP: {psp}"
+                f"following successful refund {refund.get('id')} in PSP: {psp}"
             )
             refund = self._preprocess_refund_object(refund, psp)
 

--- a/commerce_coordinator/apps/paypal/clients.py
+++ b/commerce_coordinator/apps/paypal/clients.py
@@ -3,6 +3,7 @@ import json
 
 from django.conf import settings
 from paypalserversdk.api_helper import ApiHelper
+from paypalserversdk.configuration import Environment
 from paypalserversdk.controllers.payments_controller import PaymentsController
 from paypalserversdk.http.auth.o_auth_2 import ClientCredentialsAuthCredentials
 from paypalserversdk.paypalserversdk_client import PaypalserversdkClient
@@ -17,6 +18,11 @@ class PayPalClient:
             client_credentials_auth_credentials=ClientCredentialsAuthCredentials(
                 o_auth_client_id=settings.PAYMENT_PROCESSOR_CONFIG['edx']['paypal']['client_id'],
                 o_auth_client_secret=settings.PAYMENT_PROCESSOR_CONFIG['edx']['paypal']['client_secret'],
+            ),
+            environment=(
+                Environment.SANDBOX
+                if settings.PAYMENT_PROCESSOR_CONFIG['edx']['paypal']['env'] == 'sandbox'
+                else Environment.PRODUCTION
             ),
         )
 

--- a/commerce_coordinator/apps/paypal/pipeline.py
+++ b/commerce_coordinator/apps/paypal/pipeline.py
@@ -60,6 +60,8 @@ class RefundPayPalPayment(PipelineStep):
         tag = type(self).__name__
 
         if psp != EDX_PAYPAL_PAYMENT_INTERFACE_NAME or not amount_in_cents or not ct_transaction_interaction_id:
+            logger.info(f'[{tag}] capture_id or amount_in_cents not set, '
+                        f'skipping refund for order: {order_id} with psp: {psp}')
             return PipelineCommand.CONTINUE.value
 
         if has_been_refunded:

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -441,6 +441,7 @@ PAYMENT_PROCESSOR_CONFIG = {
             'paypal_webhook_id': PAYPAL_WEBHOOK_ID,
             'client_id': '',
             'client_secret': '',
+            'env': 'sandbox',
         },
     },
 }


### PR DESCRIPTION
This PR fixes the paypal refund `RequestException('[ClientCredentialsAuth: OAuthToken is undefined or expired.]')` error on prod environment.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
