### PR TITLE
feat: log error on order fulfill task failed

### DIFF
--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -3,7 +3,7 @@ Commercetools Subscription Message tasks (Celery)
 """
 from datetime import datetime
 
-from celery import shared_task
+from celery import Task, shared_task
 from celery.utils.log import get_task_logger
 from commercetools import CommercetoolsError
 from edx_django_utils.cache import TieredCache
@@ -50,9 +50,28 @@ from commerce_coordinator.apps.lms.clients import LMSAPIClient
 logger = get_task_logger(__name__)
 
 
+class FulfillOrderPlacedTaskAfterReturn(Task):    # pylint: disable=abstract-method
+    """
+    Base class for fulfill_order_placed_message_signal_task
+    """
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        order_id = kwargs.get('order_id')
+
+        logger.error(
+            f"Post-Purchase Order Fulfillment Task failed. "
+            f"Task:{self.name}, order_id:{order_id}, Error message: {str(exc)}"
+        )
+
+
 # noinspection DuplicatedCode
-@shared_task(autoretry_for=(RequestException, CommercetoolsError), retry_kwargs={'max_retries': 5, 'countdown': 3})
+@shared_task(
+    bind=True,
+    autoretry_for=(RequestException, CommercetoolsError),
+    retry_kwargs={'max_retries': 5, 'countdown': 3},
+    base=FulfillOrderPlacedTaskAfterReturn,
+)
 def fulfill_order_placed_message_signal_task(
+    self,                   # pylint: disable=unused-argument
     order_id,
     line_item_state_id,
     source_system,

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -1,7 +1,7 @@
 """Commercetools Task Tests"""
 import logging
 from unittest import TestCase
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 from commercetools import CommercetoolsError
 from commercetools.platform.models import Order as CTOrder
@@ -150,6 +150,45 @@ class FulfillOrderPlacedMessageSignalTaskTests(TestCase):
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
         self.assertFalse(TieredCache.get_cached_response(mock_values.cache_key).is_found)
+
+    @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.is_edx_lms_order',
+           return_value=False)
+    @patch.object(fulfill_order_placed_message_signal_task, 'max_retries', 5)
+    def test_error_is_logged_on_failure(
+            self, _fn, _ct_client_init: CommercetoolsAPIClientMock, _lms_signal
+    ):
+        """
+        Test that `on_failure` logs proper error message.
+        """
+        mock_response = Mock()
+        exception = CommercetoolsError(
+            message="Order not found", response={}, errors="Order not found"
+        )
+        exception.response = mock_response
+
+        exc = exception
+        task_id = "test_task_id"
+        args = []
+        kwargs = {'order_id': 'test_order_id'}
+        einfo = Mock()
+
+        fulfill_order_placed_message_signal_task.push_request(retries=5)
+
+        with self.assertLogs('commerce_coordinator.apps.commercetools.sub_messages.tasks', level='ERROR') as log:
+            fulfill_order_placed_message_signal_task.on_failure(
+                exc=exc,
+                task_id=task_id,
+                args=args,
+                kwargs=kwargs,
+                einfo=einfo
+            )
+
+        self.assertIn(
+            "Post-Purchase Order Fulfillment Task failed. "
+            "Task:commerce_coordinator.apps.commercetools.sub_messages.tasks.fulfill_order_placed_message_signal_task,"
+            " order_id:test_order_id, Error message: Order not found",
+            log.output[0]
+        )
 
 
 @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.LMSAPIClient.deactivate_user',

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -129,7 +129,10 @@ class FulfillOrderPlacedMessageSignalTaskTests(TestCase):
         expected_data.
         """
         mock_values = _ct_client_init.return_value
-        _ = self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
+        # pylint: disable = no-value-for-parameter
+        _ = self.get_uut()(
+            *self.unpack_for_uut(mock_values.example_payload)
+        )
 
         mock_values.order_mock.assert_called_once_with(mock_values.expected_order.id)
         mock_values.customer_mock.assert_called_once_with(mock_values.expected_customer.id)
@@ -144,7 +147,10 @@ class FulfillOrderPlacedMessageSignalTaskTests(TestCase):
         """
         mock_values = _ct_client_init.return_value
 
-        ret_val = self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
+        # pylint: disable=no-value-for-parameter
+        ret_val = fulfill_order_placed_uut(
+            *self.unpack_for_uut(mock_values.example_payload)
+        )
 
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)


### PR DESCRIPTION
Emit error message on fulfill_order_placed_message_signal_task failure and emit DD alert on this error log.


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
