### PR TITLE
fix: fix log stream issue locally

### DIFF
--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -113,7 +113,8 @@ JWT_AUTH.update({
 
 ENABLE_AUTO_AUTH = True
 
-LOGGING = get_logger_config(debug=DEBUG)
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", "")
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)
 
 CELERY_BROKER_URL = "redis://:password@localhost:6379/0"
 

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -113,8 +113,7 @@ JWT_AUTH.update({
 
 ENABLE_AUTO_AUTH = True
 
-LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", "")
-LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)
+LOGGING = get_logger_config(debug=DEBUG)
 
 CELERY_BROKER_URL = "redis://:password@localhost:6379/0"
 

--- a/commerce_coordinator/settings/production.py
+++ b/commerce_coordinator/settings/production.py
@@ -11,8 +11,8 @@ TEMPLATE_DEBUG = DEBUG
 ALLOWED_HOSTS = ['*']
 
 LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", "")
-LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)
-
+LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING) if \
+    LOGGING_FORMAT_STRING else get_logger_config()
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ('JWT_AUTH',)

--- a/commerce_coordinator/settings/production.py
+++ b/commerce_coordinator/settings/production.py
@@ -10,7 +10,8 @@ TEMPLATE_DEBUG = DEBUG
 
 ALLOWED_HOSTS = ['*']
 
-LOGGING = get_logger_config()
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", "")
+LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.

--- a/commerce_coordinator/settings/utils.py
+++ b/commerce_coordinator/settings/utils.py
@@ -16,7 +16,8 @@ def get_env_setting(setting):
 
 def get_logger_config(logging_env="no_env",
                       debug=False,
-                      service_variant='commerce-coordinator'):
+                      service_variant='commerce-coordinator',
+                      format_string=''):
     """
     Return the appropriate logging config dictionary. You should assign the
     result of this to the LOGGING var in your settings.
@@ -39,8 +40,7 @@ def get_logger_config(logging_env="no_env",
         'disable_existing_loggers': False,
         'formatters': {
             'standard': {
-                'format': '%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] '
-                          '[dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] - %(message)s',
+                'format': format_string,
             },
             'syslog_format': {'format': syslog_format},
             'raw': {'format': '%(message)s'},

--- a/commerce_coordinator/settings/utils.py
+++ b/commerce_coordinator/settings/utils.py
@@ -4,6 +4,11 @@ from os import environ
 
 from django.core.exceptions import ImproperlyConfigured
 
+DEFAULT_LOGGING_FORMAT_STRING = (
+    "%(asctime)s %(levelname)s %(process)d [%(name)s] [user %(userid)s] "
+    "[ip %(remoteip)s] %(filename)s:%(lineno)d - %(message)s"
+)
+
 
 def get_env_setting(setting):
     """ Get the environment setting or raise exception """
@@ -17,7 +22,7 @@ def get_env_setting(setting):
 def get_logger_config(logging_env="no_env",
                       debug=False,
                       service_variant='commerce-coordinator',
-                      format_string=''):
+                      format_string=DEFAULT_LOGGING_FORMAT_STRING):
     """
     Return the appropriate logging config dictionary. You should assign the
     result of this to the LOGGING var in your settings.


### PR DESCRIPTION
We are moving the logging format string to the remote config to fix the logging issue locally.

We can set LOGGING_FORMAT_STRING in our private.py file to get logs for local env like:

`LOGGING_FORMAT_STRING = '%(asctime)s %(levelname)s %(process)d [%(name)s] [user %(userid)s] [ip %(remoteip)s] %(filename)s:%(lineno)d - %(message)s`'

[edx-internal](https://github.com/edx/edx-internal/pull/12516)

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
