### PR TITLE
feat: handle enrollment code orders gracefully

### DIFF
--- a/commerce_coordinator/apps/commercetools/catalog_info/edx_utils.py
+++ b/commerce_coordinator/apps/commercetools/catalog_info/edx_utils.py
@@ -47,6 +47,8 @@ def get_edx_lms_user_name(customer: CTCustomer):
 
 
 def get_edx_successful_payment_info(order: CTOrder):
+    if not order.payment_info:
+        return None, None
     for pr in order.payment_info.payments:
         pmt = pr.obj
         if pmt.payment_status.interface_code == PAYMENT_STATUS_INTERFACE_CODE_SUCCEEDED and pmt.interface_id:

--- a/commerce_coordinator/apps/commercetools/data.py
+++ b/commerce_coordinator/apps/commercetools/data.py
@@ -96,9 +96,9 @@ def convert_customer(customer: CTCustomer) -> User:
 
 
 def convert_payment_info(payment_info: CTPaymentInfo) -> str:
-    if len(payment_info.payments) > 0:
+    if payment_info and len(payment_info.payments) > 0:
         return un_ls(payment_info.payments[-1].obj.payment_method_info.name)
-    return "Unknown"
+    return "Unknown"  # This string should not be changed, we have conditional logic that depends on it on frontend.
 
 
 def order_from_commercetools(order: CTOrder, customer: CTCustomer) -> LegacyOrder:

--- a/commerce_coordinator/settings/local.py
+++ b/commerce_coordinator/settings/local.py
@@ -18,6 +18,7 @@ INSTALLED_APPS += (
 CORS_ORIGIN_WHITELIST = [
     'http://localhost:1996',  # frontend-app-ecommerce
     'http://localhost:1998',  # frontend-app-payment
+    'http://localhost:3000',  # commercetools-frontend
 ]
 # END CORS CONFIGURATION
 


### PR DESCRIPTION
when order is enrollmentcode order, the `order.paymentInfo` is null

we access order.paymentInfo at 3 places in CC

- While getting orders for order history page
- While refunding the order
- While getting receipt URL for the order (already handled gracefully)

This PR gracefully handle the areas

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
