### PR TITLE
fix: concurrency issue in fulfillment task

### DIFF
--- a/commerce_coordinator/apps/commercetools/tests/test_views.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_views.py
@@ -171,6 +171,19 @@ class OrderFulfillViewTests(APITestCase):
         # Check 403 Forbidden
         self.assertEqual(response.status_code, 403)
 
+    def test_view_skips_if_task_lock_already_held(self, _mock_signal):
+        """Check that if task lock is already held, signal is not sent and response is 200."""
+
+        self.client.login(username=self.test_staff_username, password=self.test_password)
+
+        with patch('commerce_coordinator.apps.commercetools.views.acquire_task_lock',
+                   return_value=False):
+            response = self.client.post(self.url, data=EXAMPLE_COMMERCETOOLS_ORDER_FULFILL_MESSAGE, format='json')
+
+            self.assertEqual(response.status_code, 200)
+            # Signal should not have been called
+            _mock_signal.assert_not_called()
+
 
 @ddt.ddt
 @patch('commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch'

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -56,7 +56,7 @@ class OrderFulfillView(SingleInvocationAPIView):
 
         if not acquire_task_lock(task_key):
             logger.info(
-                f"Task {task_key} is already running. Exiting current task."
+                f"Task {task_key} is already running. Exiting current task. Order ID: {order_id}."
             )
             return Response(status=status.HTTP_200_OK)
 


### PR DESCRIPTION
The fulfill_placed_order_signal_task Celery task is being triggered twice, which should not be happening. This occurs because AWS emits LineItemTransitionState signals simultaneously within a second, causing multiple executions of the task.

This PR makes sure the task is not triggered more than once.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
