### PR TITLE
feat: gracefully handle mobile order refund in CC

### DIFF
--- a/commerce_coordinator/apps/commercetools/clients.py
+++ b/commerce_coordinator/apps/commercetools/clients.py
@@ -83,7 +83,7 @@ from commerce_coordinator.apps.commercetools.utils import (
     find_refund_transaction,
     get_refund_transaction_id_from_mobile_order,
     handle_commercetools_error,
-    translate_refund_status_to_transaction_status,
+    translate_refund_status_to_transaction_status
 )
 from commerce_coordinator.apps.core.constants import ORDER_HISTORY_PER_SYSTEM_REQ_LIMIT
 
@@ -899,8 +899,7 @@ class CommercetoolsAPIClient:
                 f"Line Item IDs: {', '.join(item.id for item in line_items)}",
                 True
             )
-            # raise err
-            return self.get_order_by_id(order_id)
+            raise err
 
     def retire_customer_anonymize_fields(
         self,

--- a/commerce_coordinator/apps/commercetools/clients.py
+++ b/commerce_coordinator/apps/commercetools/clients.py
@@ -81,7 +81,7 @@ from commerce_coordinator.apps.commercetools.catalog_info.foundational_types imp
 from commerce_coordinator.apps.commercetools.utils import (
     find_latest_refund,
     find_refund_transaction,
-    get_refund_transaction_id_from_mobile_order,
+    get_refund_transaction_id_from_order,
     handle_commercetools_error,
     translate_refund_status_to_transaction_status
 )
@@ -559,10 +559,11 @@ class CommercetoolsAPIClient:
         try:
             logger.info(
                 f"[CommercetoolsAPIClient.update_return_payment_state_for_mobile_order] - "
-                f"Updating return payment state for return item(s) {return_line_item_return_ids} to 'REFUNDED'."
+                f"Updating return payment state for return item(s) "
+                f"{return_line_item_return_ids} to '{ReturnPaymentState.NOT_REFUNDED}'."
             )
 
-            refund_transaction_id = get_refund_transaction_id_from_mobile_order(order)
+            refund_transaction_id = get_refund_transaction_id_from_order(order)
             update_actions = []
 
             for return_item_id in return_line_item_return_ids:
@@ -588,7 +589,8 @@ class CommercetoolsAPIClient:
 
             logger.info(
                 f"[CommercetoolsAPIClient.update_return_payment_state_for_mobile_order] - "
-                f"Successfully updated ReturnPaymentState to 'REFUNDED' for order ID: {order.id}. "
+                f"Successfully updated ReturnPaymentState to '{ReturnPaymentState.NOT_REFUNDED}' "
+                f"for order ID: {order.id}. Added refund transaction ID: {refund_transaction_id}."
                 f"Updated return item IDs: {', '.join(return_line_item_return_ids)}."
             )
             return updated_order

--- a/commerce_coordinator/apps/commercetools/clients.py
+++ b/commerce_coordinator/apps/commercetools/clients.py
@@ -61,7 +61,7 @@ from commercetools.platform.models import (
     TransactionState,
     TransactionType,
     TypeDraft,
-    TypeResourceIdentifier,
+    TypeResourceIdentifier
 )
 from commercetools.platform.models.state import State as LineItemState
 from django.conf import settings
@@ -81,8 +81,9 @@ from commerce_coordinator.apps.commercetools.catalog_info.foundational_types imp
 from commerce_coordinator.apps.commercetools.utils import (
     find_latest_refund,
     find_refund_transaction,
+    get_refund_transaction_id_from_mobile_order,
     handle_commercetools_error,
-    translate_refund_status_to_transaction_status
+    translate_refund_status_to_transaction_status,
 )
 from commerce_coordinator.apps.core.constants import ORDER_HISTORY_PER_SYSTEM_REQ_LIMIT
 
@@ -498,61 +499,6 @@ class CommercetoolsAPIClient:
                                        err, f"Unable to create return for order {order_id}")
             raise err
 
-    def _update_return_payment_state(
-        self,
-        order_id: str,
-        order_version: int,
-        return_line_item_return_ids: List[str],
-        payment_state: ReturnPaymentState,
-        log_prefix: str = ""
-    ) -> Union[Order, None]:
-        """
-        Internal helper to update ReturnPaymentState for one or more return items on an order.
-
-        Args:
-            order_id (str): Order ID
-            order_version (int): Order version
-            return_line_item_return_ids (List[str]): Return item IDs
-            payment_state (ReturnPaymentState): New state to set
-            log_prefix (str): Logging context prefix
-
-        Returns (Order): Updated order object or
-        Raises Exception: Error if update was unsuccessful.
-        """
-        try:
-            logger.info(
-                f"{log_prefix} Updating return payment state for return item(s) "
-                f"{return_line_item_return_ids} to '{payment_state}'."
-            )
-
-            return_payment_state_actions = [
-                OrderSetReturnPaymentStateAction(
-                    return_item_id=return_item_id,
-                    payment_state=payment_state
-                ) for return_item_id in return_line_item_return_ids
-            ]
-
-            updated_order = self.base_client.orders.update_by_id(
-                id=order_id,
-                version=order_version,
-                actions=return_payment_state_actions,
-            )
-
-            logger.info(
-                f"{log_prefix} Successfully updated ReturnPaymentState to '{payment_state}' for order ID: {order_id}. "
-                f"Updated return item IDs: {', '.join(return_line_item_return_ids)}."
-            )
-            return updated_order
-
-        except CommercetoolsError as err:
-            handle_commercetools_error(
-                f"{log_prefix} update_return_payment_state",
-                err,
-                f"Unable to update ReturnPaymentState of order {order_id} to '{payment_state}' "
-                f"for return item IDs: {', '.join(return_line_item_return_ids)} at version {order_version}."
-            )
-            raise err
-
     def update_return_payment_state_for_enrollment_code_purchase(
         self,
         order_id: str,
@@ -572,42 +518,89 @@ class CommercetoolsAPIClient:
         Raises Exception: Error if update was unsuccessful.
         """
 
-        return self._update_return_payment_state(
-            order_id,
-            order_version,
-            return_line_item_return_ids,
-            ReturnPaymentState.NOT_REFUNDED,
-            log_prefix="[CommercetoolsAPIClient.update_return_payment_state_for_enrollment_code_purchase] - "
-        )
+        try:
+            logger.info(
+                f"[CommercetoolsAPIClient."
+                "update_return_payment_state_for_enrollment_code_purchase] - "
+                "Updating payment state for return "
+                f"with ids {return_line_item_return_ids} to '{ReturnPaymentState.NOT_REFUNDED}'."
+            )
+            return_payment_state_actions = []
+            for return_line_item_return_id in return_line_item_return_ids:
+                return_payment_state_actions.append(OrderSetReturnPaymentStateAction(
+                    return_item_id=return_line_item_return_id,
+                    payment_state=ReturnPaymentState.NOT_REFUNDED,
+                ))
+
+            updated_order = self.base_client.orders.update_by_id(
+                id=order_id,
+                version=order_version,
+                actions=return_payment_state_actions,
+            )
+            logger.info(f"Successfully updated return payment state to not refunded "
+                        f"for enrollment code purchase - order_id: {order_id}")
+            return updated_order
+        except CommercetoolsError as err:
+            handle_commercetools_error(
+                "[CommercetoolsAPIClient."
+                "update_return_payment_state_for_enrollment_code_purchase]",
+                err, f"Unable to update ReturnPaymentState of order {order_id}"
+            )
+            raise err
 
     def update_return_payment_state_for_mobile_order(
         self,
-        order_id: str,
-        order_version: int,
+        order: Order,
         return_line_item_return_ids: List[str],
     ) -> Union[Order, None]:
         """
         Update the ReturnPaymentState to 'Refunded' for each LineItemReturnItem in a mobile order.
-
-        Args:
-            order_id (str): Unique identifier (UUID) of the order.
-            order_version (int): Current version of the order to ensure optimistic concurrency control.
-            return_line_item_return_ids (List[str]): List of LineItemReturnItem IDs to update.
-                Although mobile orders typically have only a single return item,
-                this is structured as a list for consistency with other update functions.
-
-        Returns:
-            Order: Updated order object
-        Raises:
-            Exception: Error if update was unsuccessful.
         """
-        return self._update_return_payment_state(
-            order_id,
-            order_version,
-            return_line_item_return_ids,
-            ReturnPaymentState.REFUNDED,
-            log_prefix="[CommercetoolsAPIClient.update_return_payment_state_for_mobile_order] - "
-        )
+        try:
+            logger.info(
+                f"[CommercetoolsAPIClient.update_return_payment_state_for_mobile_order] - "
+                f"Updating return payment state for return item(s) {return_line_item_return_ids} to 'REFUNDED'."
+            )
+
+            refund_transaction_id = get_refund_transaction_id_from_mobile_order(order)
+            update_actions = []
+
+            for return_item_id in return_line_item_return_ids:
+                update_actions.append(OrderSetReturnPaymentStateAction(
+                    return_item_id=return_item_id,
+                    payment_state=ReturnPaymentState.REFUNDED,
+                ))
+
+                if refund_transaction_id:
+                    update_actions.append(OrderSetReturnItemCustomTypeAction(
+                        return_item_id=return_item_id,
+                        type=TypeResourceIdentifier(key="returnItemCustomType"),
+                        fields=FieldContainer({
+                            "transactionId": refund_transaction_id,
+                        }),
+                    ))
+
+            updated_order = self.base_client.orders.update_by_id(
+                id=order.id,
+                version=order.version,
+                actions=update_actions,
+            )
+
+            logger.info(
+                f"[CommercetoolsAPIClient.update_return_payment_state_for_mobile_order] - "
+                f"Successfully updated ReturnPaymentState to 'REFUNDED' for order ID: {order.id}. "
+                f"Updated return item IDs: {', '.join(return_line_item_return_ids)}."
+            )
+            return updated_order
+
+        except CommercetoolsError as err:
+            handle_commercetools_error(
+                "[CommercetoolsAPIClient.update_return_payment_state_for_mobile_order]",
+                err,
+                f"Unable to update ReturnPaymentState of order {order.id} to 'REFUNDED' "
+                f"for return item IDs: {', '.join(return_line_item_return_ids)} at version {order.version}."
+            )
+            raise err
 
     def update_return_payment_state_after_successful_refund(
         self,
@@ -906,7 +899,8 @@ class CommercetoolsAPIClient:
                 f"Line Item IDs: {', '.join(item.id for item in line_items)}",
                 True
             )
-            raise err
+            # raise err
+            return self.get_order_by_id(order_id)
 
     def retire_customer_anonymize_fields(
         self,

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -374,7 +374,7 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
 
     if hasattr(order.custom, 'fields') and order.custom.fields:
         print('\n\n\n\n\n  order.custom.fields',  order.custom.fields, '\n\n\n\n\n')
-        is_mobile_order = order.custom.fields.get("mobileOrder")
+        is_mobile_order = order.custom.fields.get(TwoUKeys.ORDER_MOBILE_ORDER)
 
     print('\n\n\n\n\n is_mobile_order', is_mobile_order, '\n\n\n\n\n')
     # Return payment if payment id is set

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -425,7 +425,7 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
             logger.info(f'[CT-{tag}] payment {psp_payment_id} not refunded, '
                         f'sending Slack notification, message id: {message_id}')
 
-    elif psp_payment_id is None and order.total_price.cent_amount == 0 and not is_mobile_order:
+    elif psp_payment_id is None and order.total_price.cent_amount == 0:
         client.update_return_payment_state_for_enrollment_code_purchase(
             order_id=order.id,
             order_version=order.version,

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -368,8 +368,8 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
                                    get_line_item_lms_entitlement_id(line_item) for line_item in get_edx_items(order)}
 
     is_mobile_order = False
-    if hasattr(order.custom, 'fields') and order.custom.fields:
-        is_mobile_order = order.custom.fields.get(TwoUKeys.ORDER_MOBILE_ORDER)
+    if hasattr(order, 'custom') and hasattr(order.custom, 'fields'):
+        is_mobile_order = order.custom.fields.get(TwoUKeys.ORDER_MOBILE_ORDER, False)
 
     # Return payment if payment id is set
     # pylint: disable=too-many-nested-blocks

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -368,9 +368,15 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
                                    get_line_item_lms_entitlement_id(line_item) for line_item in get_edx_items(order)}
 
     is_mobile_order = False
+
+    print('\n\n\n\n\n hasattr(order.custom, fields)', hasattr(order.custom, 'fields'), '\n\n\n\n\n')
+    print('\n\n\n\n\n order.total_price.cent_amount', order.total_price.cent_amount, '\n\n\n\n\n')
+
     if hasattr(order.custom, 'fields') and order.custom.fields:
+        print('\n\n\n\n\n  order.custom.fields',  order.custom.fields, '\n\n\n\n\n')
         is_mobile_order = order.custom.fields.get("mobileOrder")
 
+    print('\n\n\n\n\n is_mobile_order', is_mobile_order, '\n\n\n\n\n')
     # Return payment if payment id is set
     # pylint: disable=too-many-nested-blocks
     if psp_payment_id is not None and not is_mobile_order:
@@ -425,7 +431,7 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
             logger.info(f'[CT-{tag}] payment {psp_payment_id} not refunded, '
                         f'sending Slack notification, message id: {message_id}')
 
-    elif psp_payment_id is None and order.total_price.cent_amount == 0:
+    elif psp_payment_id is None and order.total_price.cent_amount == 0 and not is_mobile_order:
         client.update_return_payment_state_for_enrollment_code_purchase(
             order_id=order.id,
             order_version=order.version,
@@ -433,8 +439,7 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
         )
     elif is_mobile_order:
         client.update_return_payment_state_for_mobile_order(
-            order_id=order.id,
-            order_version=order.version,
+            order=order,
             return_line_item_return_ids=return_line_item_return_ids,
         )
 

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -368,15 +368,9 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
                                    get_line_item_lms_entitlement_id(line_item) for line_item in get_edx_items(order)}
 
     is_mobile_order = False
-
-    print('\n\n\n\n\n hasattr(order.custom, fields)', hasattr(order.custom, 'fields'), '\n\n\n\n\n')
-    print('\n\n\n\n\n order.total_price.cent_amount', order.total_price.cent_amount, '\n\n\n\n\n')
-
     if hasattr(order.custom, 'fields') and order.custom.fields:
-        print('\n\n\n\n\n  order.custom.fields',  order.custom.fields, '\n\n\n\n\n')
         is_mobile_order = order.custom.fields.get(TwoUKeys.ORDER_MOBILE_ORDER)
 
-    print('\n\n\n\n\n is_mobile_order', is_mobile_order, '\n\n\n\n\n')
     # Return payment if payment id is set
     # pylint: disable=too-many-nested-blocks
     if psp_payment_id is not None and not is_mobile_order:

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -473,7 +473,9 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
     @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.is_edx_lms_order')
     @patch('commerce_coordinator.apps.stripe.pipeline.StripeAPIClient')
     @patch(
-        'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.update_return_payment_state_for_enrollment_code_purchase')
+        'commerce_coordinator.apps.commercetools.clients.'
+        'CommercetoolsAPIClient.update_return_payment_state_for_enrollment_code_purchase'
+    )
     @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.get_edx_psp_payment_id')
     def test_enrollment_code_purchase_triggers_update_return_payment_state(
             self,
@@ -508,7 +510,9 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
     @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.is_edx_lms_order')
     @patch('commerce_coordinator.apps.stripe.pipeline.StripeAPIClient')
     @patch(
-        'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.update_return_payment_state_for_mobile_order')
+        'commerce_coordinator.apps.commercetools.clients.'
+        'CommercetoolsAPIClient.update_return_payment_state_for_mobile_order'
+    )
     def test_mobile_order_triggers_update_return_payment_state_for_mobile_order(
             self,
             mobile_order_mock: MagicMock,

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -98,6 +98,8 @@ class CommercetoolsAPIClientMock(MagicMock):
         self.create_return_for_order = self.create_return_item_mock
         self.create_return_payment_transaction = self.payment_mock
         self.update_return_payment_state_after_successful_refund = self.order_mock
+        self.update_return_payment_state_for_enrollment_code_purchase = self.order_mock
+        self.update_return_payment_state_for_mobile_order = self.order_mock
 
         self.expected_order = self.order_mock.return_value
         self.expected_customer = self.customer_mock.return_value
@@ -380,7 +382,11 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
                 'create_return_for_order': self.mock.create_return_for_order,
                 'create_return_payment_transaction': self.mock.create_return_payment_transaction,
                 'update_return_payment_state_after_successful_refund':
-                    self.mock.update_return_payment_state_after_successful_refund
+                    self.mock.update_return_payment_state_after_successful_refund,
+                'update_return_payment_state_for_enrollment_code_purchase':
+                    self.mock.update_return_payment_state_for_enrollment_code_purchase,
+                'update_return_payment_state_for_mobile_order':
+                    self.mock.update_return_payment_state_for_mobile_order
             }
         )
 
@@ -463,6 +469,77 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
         _mock_psp_payment_id.return_value = 'mock_payment_intent_id'
 
         self.get_uut()(*self.unpack_for_uut(self.mock.example_payload))
+
+    @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.is_edx_lms_order')
+    @patch('commerce_coordinator.apps.stripe.pipeline.StripeAPIClient')
+    @patch(
+        'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.update_return_payment_state_for_enrollment_code_purchase')
+    @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.get_edx_psp_payment_id')
+    def test_enrollment_code_purchase_triggers_update_return_payment_state(
+            self,
+            mock_get_psp_payment_id: MagicMock,
+            enrollment_code_mock: MagicMock,
+            _stripe_api_mock: MagicMock,
+            _lms_signal
+    ):
+        """Test enrollment code purchase (zero cost order) triggers correct return payment update."""
+        mock_values = self.mock
+        mock_order = mock_values.order_mock.return_value
+        mock_order.total_price.cent_amount = 0
+        mock_get_psp_payment_id.return_value = None
+
+        ret_val = self.get_uut()(*self.unpack_for_uut(self.mock.example_payload))
+
+        # Validate call to enrollment code refund path
+        enrollment_code_mock.assert_called_once_with(
+            order_id=mock_order.id,
+            order_version=mock_order.version,
+            return_line_item_return_ids=[
+                item["id"] for item in self.mock.example_payload["return_items"]
+            ]
+        )
+
+        # Validate return value
+        self.assertTrue(ret_val)
+
+        # Ensure refund via PSP was not attempted
+        _stripe_api_mock.return_value.refund_payment_intent.assert_not_called()
+
+    @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.is_edx_lms_order')
+    @patch('commerce_coordinator.apps.stripe.pipeline.StripeAPIClient')
+    @patch(
+        'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.update_return_payment_state_for_mobile_order')
+    def test_mobile_order_triggers_update_return_payment_state_for_mobile_order(
+            self,
+            mobile_order_mock: MagicMock,
+            _stripe_api_mock: MagicMock,
+            _lms_signal
+    ):
+        """Test mobile order triggers update_return_payment_state_for_mobile_order"""
+        mock_values = self.mock
+        mock_order = mock_values.order_mock.return_value
+
+        # Set up mobile order
+        mock_order.total_price.cent_amount = 100
+        mock_order.custom = MagicMock()
+        mock_order.custom.fields = {'mobileOrder': True}
+
+        ret_val = self.get_uut()(*self.unpack_for_uut(self.mock.example_payload))
+
+        # Assert that the method was called with expected args
+        mobile_order_mock.assert_called_once_with(
+            order_id=mock_order.id,
+            order_version=mock_order.version,
+            return_line_item_return_ids=[
+                item["id"] for item in self.mock.example_payload["return_items"]
+            ]
+        )
+
+        # Make sure the return value is still True
+        self.assertTrue(ret_val)
+
+        # Other PSP refund logic should not trigger
+        _stripe_api_mock.return_value.refund_payment_intent.assert_not_called()
 
 
 @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.OrderRefundRequested.run_filter')

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -528,8 +528,7 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
 
         # Assert that the method was called with expected args
         mobile_order_mock.assert_called_once_with(
-            order_id=mock_order.id,
-            order_version=mock_order.version,
+            order=mock_order,
             return_line_item_return_ids=[
                 item["id"] for item in self.mock.example_payload["return_items"]
             ]
@@ -540,6 +539,10 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
 
         # Other PSP refund logic should not trigger
         _stripe_api_mock.return_value.refund_payment_intent.assert_not_called()
+
+        # clear set fields
+        mock_order.custom = MagicMock()
+        mock_order.custom.fields = {}
 
 
 @patch('commerce_coordinator.apps.commercetools.sub_messages.tasks.OrderRefundRequested.run_filter')

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -372,6 +372,11 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
         super().setUp()
         self.mock = CommercetoolsAPIClientMock()
 
+        # Force reset nested mocked return object
+        order_return = self.mock.order_mock.return_value
+        if hasattr(order_return, "custom") and hasattr(order_return.custom, "fields"):
+            order_return.custom.fields.clear()
+
         MonkeyPatch.monkey(
             CommercetoolsAPIClient,
             {

--- a/commerce_coordinator/apps/commercetools/tests/test_clients.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_clients.py
@@ -514,6 +514,36 @@ class ClientTests(TestCase):
             )
             self.assertEqual(result.return_info[1].items[0].payment_state, ReturnPaymentState.NOT_REFUNDED)
 
+    def test_order_return_payment_state_refunded(self):
+        base_url = self.client_set.get_base_url_from_client()
+
+        # Mocked order to be passed in to update method
+        mock_order = gen_order("mock_order_id")
+        mock_order.version = "2"
+        mock_return_item = gen_return_item("mock_return_item_id", ReturnPaymentState.INITIAL)
+        mock_return_info = ReturnInfo(items=[mock_return_item])
+        mock_order.return_info.append(mock_return_info)
+
+        # Mocked expected order received after CT SDK call to update the order
+        mock_response_order = gen_order("mock_order_id")
+        mock_response_order.version = "3"
+        mock_response_return_item = gen_return_item("mock_return_item_id", ReturnPaymentState.REFUNDED)
+        mock_response_return_info = ReturnInfo(items=[mock_response_return_item])
+        mock_response_order.return_info.append(mock_response_return_info)
+
+        with requests_mock.Mocker(real_http=True, case_sensitive=False) as mocker:
+            mocker.post(
+                f"{base_url}orders/mock_order_id",
+                json=mock_response_order.serialize(),
+                status_code=200
+            )
+
+            result = self.client_set.client.update_return_payment_state_for_mobile_order(
+                mock_order,
+                [mock_response_return_item.line_item_id],
+            )
+            self.assertEqual(result.return_info[1].items[0].payment_state, ReturnPaymentState.REFUNDED)
+
     def test_successful_order_return_payment_state_update(self):
         base_url = self.client_set.get_base_url_from_client()
 

--- a/commerce_coordinator/apps/commercetools/tests/test_utils.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_utils.py
@@ -482,20 +482,3 @@ class TestGetRefundTransactionIdFromMobileOrder(unittest.TestCase):
 
         result = get_refund_transaction_id_from_order(order)
         self.assertEqual(result, "")
-
-    def test_get_refund_transaction_id_with_no_payments(self):
-        # Mock an order with no payments
-        order = MagicMock()
-        order.payment_info = MagicMock()
-        order.payment_info.payments = []
-
-        result = get_refund_transaction_id_from_order(order)
-        self.assertEqual(result, "")
-
-    def test_get_refund_transaction_id_with_no_payment_info(self):
-        # Mock an order with no payment_info
-        order = MagicMock()
-        order.payment_info = None
-
-        result = get_refund_transaction_id_from_order(order)
-        self.assertEqual(result, "")

--- a/commerce_coordinator/apps/commercetools/tests/test_utils.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_utils.py
@@ -26,11 +26,12 @@ from commerce_coordinator.apps.commercetools.utils import (
     find_latest_refund,
     find_refund_transaction,
     get_braze_client,
+    get_refund_transaction_id_from_mobile_order,
     has_full_refund_transaction,
     has_refund_transaction,
     send_fulfillment_error_email,
     send_order_confirmation_email,
-    translate_refund_status_to_transaction_status, get_refund_transaction_id_from_mobile_order
+    translate_refund_status_to_transaction_status
 )
 
 

--- a/commerce_coordinator/apps/commercetools/tests/test_utils.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_utils.py
@@ -30,7 +30,7 @@ from commerce_coordinator.apps.commercetools.utils import (
     has_refund_transaction,
     send_fulfillment_error_email,
     send_order_confirmation_email,
-    translate_refund_status_to_transaction_status
+    translate_refund_status_to_transaction_status, get_refund_transaction_id_from_mobile_order
 )
 
 
@@ -438,3 +438,63 @@ class TestRetirementAnonymizingTestCase(unittest.TestCase):
     def test_create_retired_fields_with_invalid_salt_list(self):
         with self.assertRaises(ValueError):
             create_retired_fields(self.field_value, "invalid_salt_list")
+
+
+class TestGetRefundTransactionIdFromMobileOrder(unittest.TestCase):
+    """
+    Tests for get_refund_transaction_id_from_mobile_order function
+    """
+
+    def test_get_refund_transaction_id_with_refund(self):
+        # Mock an order with a refund transaction
+        refund_transaction = MagicMock()
+        refund_transaction.type = TransactionType.REFUND
+        refund_transaction.id = "refund_transaction_id"
+
+        payment = MagicMock()
+        payment.transactions = [refund_transaction]
+
+        payment_reference = MagicMock()
+        payment_reference.obj = payment
+
+        order = MagicMock()
+        order.payment_info = MagicMock()
+        order.payment_info.payments = [payment_reference]
+
+        result = get_refund_transaction_id_from_mobile_order(order)
+        self.assertEqual(result, "refund_transaction_id")
+
+    def test_get_refund_transaction_id_without_refund(self):
+        # Mock an order with no refund transactions
+        charge_transaction = MagicMock()
+        charge_transaction.type = TransactionType.CHARGE
+
+        payment = MagicMock()
+        payment.transactions = [charge_transaction]
+
+        payment_reference = MagicMock()
+        payment_reference.obj = payment
+
+        order = MagicMock()
+        order.payment_info = MagicMock()
+        order.payment_info.payments = [payment_reference]
+
+        result = get_refund_transaction_id_from_mobile_order(order)
+        self.assertEqual(result, "")
+
+    def test_get_refund_transaction_id_with_no_payments(self):
+        # Mock an order with no payments
+        order = MagicMock()
+        order.payment_info = MagicMock()
+        order.payment_info.payments = []
+
+        result = get_refund_transaction_id_from_mobile_order(order)
+        self.assertEqual(result, "")
+
+    def test_get_refund_transaction_id_with_no_payment_info(self):
+        # Mock an order with no payment_info
+        order = MagicMock()
+        order.payment_info = None
+
+        result = get_refund_transaction_id_from_mobile_order(order)
+        self.assertEqual(result, "")

--- a/commerce_coordinator/apps/commercetools/tests/test_utils.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_utils.py
@@ -26,7 +26,7 @@ from commerce_coordinator.apps.commercetools.utils import (
     find_latest_refund,
     find_refund_transaction,
     get_braze_client,
-    get_refund_transaction_id_from_mobile_order,
+    get_refund_transaction_id_from_order,
     has_full_refund_transaction,
     has_refund_transaction,
     send_fulfillment_error_email,
@@ -462,7 +462,7 @@ class TestGetRefundTransactionIdFromMobileOrder(unittest.TestCase):
         order.payment_info = MagicMock()
         order.payment_info.payments = [payment_reference]
 
-        result = get_refund_transaction_id_from_mobile_order(order)
+        result = get_refund_transaction_id_from_order(order)
         self.assertEqual(result, "refund_transaction_id")
 
     def test_get_refund_transaction_id_without_refund(self):
@@ -480,7 +480,7 @@ class TestGetRefundTransactionIdFromMobileOrder(unittest.TestCase):
         order.payment_info = MagicMock()
         order.payment_info.payments = [payment_reference]
 
-        result = get_refund_transaction_id_from_mobile_order(order)
+        result = get_refund_transaction_id_from_order(order)
         self.assertEqual(result, "")
 
     def test_get_refund_transaction_id_with_no_payments(self):
@@ -489,7 +489,7 @@ class TestGetRefundTransactionIdFromMobileOrder(unittest.TestCase):
         order.payment_info = MagicMock()
         order.payment_info.payments = []
 
-        result = get_refund_transaction_id_from_mobile_order(order)
+        result = get_refund_transaction_id_from_order(order)
         self.assertEqual(result, "")
 
     def test_get_refund_transaction_id_with_no_payment_info(self):
@@ -497,5 +497,5 @@ class TestGetRefundTransactionIdFromMobileOrder(unittest.TestCase):
         order = MagicMock()
         order.payment_info = None
 
-        result = get_refund_transaction_id_from_mobile_order(order)
+        result = get_refund_transaction_id_from_order(order)
         self.assertEqual(result, "")

--- a/commerce_coordinator/apps/commercetools/utils.py
+++ b/commerce_coordinator/apps/commercetools/utils.py
@@ -261,6 +261,26 @@ def find_latest_refund(payment: Payment):
             return transaction.id
     return ''
 
+def get_refund_transaction_id_from_mobile_order(order: Order) -> str:
+    """
+    Utility to find the refund transaction ID in a mobile order.
+
+    Args:
+        order (Order): The Commercetools order object.
+
+    Returns:
+        str: The ID of the refund transaction, or an empty string if no refund transaction exists.
+    """
+    refund_transactions = []
+
+    if order.payment_info and order.payment_info.payments:
+        for paymentReference in order.payment_info.payments:
+            payment = paymentReference.obj
+            for transaction in payment.transactions:
+                if transaction.type == TransactionType.REFUND:
+                    return transaction.id
+
+    return ''
 
 def translate_refund_status_to_transaction_status(refund_status: str):
     """

--- a/commerce_coordinator/apps/commercetools/utils.py
+++ b/commerce_coordinator/apps/commercetools/utils.py
@@ -262,7 +262,7 @@ def find_latest_refund(payment: Payment):
     return ''
 
 
-def get_refund_transaction_id_from_mobile_order(order: Order) -> str:
+def get_refund_transaction_id_from_order(order: Order) -> str:
     """
     Utility to find the refund transaction ID in a mobile order.
 
@@ -272,13 +272,10 @@ def get_refund_transaction_id_from_mobile_order(order: Order) -> str:
     Returns:
         str: The ID of the refund transaction, or an empty string if no refund transaction exists.
     """
-    if order.payment_info and order.payment_info.payments:
-        for paymentReference in order.payment_info.payments:
-            payment = paymentReference.obj
-            for transaction in payment.transactions:
-                if transaction.type == TransactionType.REFUND:
-                    return transaction.id
-
+    latest_payment = order.payment_info.payments[-1].obj
+    for transaction in latest_payment.transactions:
+        if transaction.type == TransactionType.REFUND:
+            return transaction.id
     return ''
 
 

--- a/commerce_coordinator/apps/commercetools/utils.py
+++ b/commerce_coordinator/apps/commercetools/utils.py
@@ -261,6 +261,7 @@ def find_latest_refund(payment: Payment):
             return transaction.id
     return ''
 
+
 def get_refund_transaction_id_from_mobile_order(order: Order) -> str:
     """
     Utility to find the refund transaction ID in a mobile order.
@@ -271,8 +272,6 @@ def get_refund_transaction_id_from_mobile_order(order: Order) -> str:
     Returns:
         str: The ID of the refund transaction, or an empty string if no refund transaction exists.
     """
-    refund_transactions = []
-
     if order.payment_info and order.payment_info.payments:
         for paymentReference in order.payment_info.payments:
             payment = paymentReference.obj
@@ -281,6 +280,7 @@ def get_refund_transaction_id_from_mobile_order(order: Order) -> str:
                     return transaction.id
 
     return ''
+
 
 def translate_refund_status_to_transaction_status(refund_status: str):
     """

--- a/commerce_coordinator/apps/iap/views.py
+++ b/commerce_coordinator/apps/iap/views.py
@@ -109,7 +109,7 @@ class MobileCreateOrderView(APIView):
                 customer_id=customer.id,
                 # TODO: finalize source of these
                 payment_method="Dummy Card",
-                payment_status="Dummy Success",
+                payment_status="succeeded",
                 payment_processor=data.payment_processor,
                 # TODO: fetch from purchase token
                 psp_payment_id="Dummy-" + str(uuid.uuid4()),


### PR DESCRIPTION
For mobile orders, we want to simply create a return and mark it refunded without doing any psp refund.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
