### PR TITLE
fix: fix cart discount key to get cartPredicate

### DIFF
--- a/commerce_coordinator/apps/commercetools/http_api_client.py
+++ b/commerce_coordinator/apps/commercetools/http_api_client.py
@@ -127,7 +127,7 @@ class CTCustomAPIClient:
         bundle_offer_without_codes = self._make_request(
             "GET",
             "cart-discounts",
-            params={"where": query_params, "sort": "sortOrder desc"},
+            params={"where": query_params, "sort": "sortOrder desc", "offset": 0, "limit": 100},
         )
         if not bundle_offer_without_codes:
             return []

--- a/commerce_coordinator/apps/lms/tests/test_utils.py
+++ b/commerce_coordinator/apps/lms/tests/test_utils.py
@@ -80,12 +80,12 @@ class TestGetProgramOffer(unittest.TestCase):
         self.cart_discounts = [
             {
                 "key": "BUNDLE_15_OFF",
-                "target": {"predicate": 'custom.bundleId is defined and (custom.bundleId = "bundle-key-123")'},
+                "cartPredicate": 'custom.bundleId is defined and (custom.bundleId = "bundle-key-123")',
                 "value": {"type": "absolute", "money": [{"centAmount": 1500}]}
             },
             {
                 "key": DEFAULT_BUNDLE_DISCOUNT_KEY,
-                "target": {"predicate": 'custom.bundleId is defined and (custom.bundleId != "bundle-key-123")'},
+                "cartPredicate": 'custom.bundleId is defined and (custom.bundleId != "bundle-key-123")',
                 "value": {"type": "relative", "permyriad": 1000}
             }
         ]
@@ -121,7 +121,7 @@ class TestGetProgramOffer(unittest.TestCase):
         cart_discounts = [
             {
                 "key": DEFAULT_BUNDLE_DISCOUNT_KEY,
-                "target": {"predicate": 'custom.bundleId != "bundle_3"'},
+                "cartPredicate": 'custom.bundleId != "bundle_3"',
                 "value": {"type": CT_ABSOLUTE_DISCOUNT_TYPE, "money": [{"centAmount": 1000}]}
             }
         ]

--- a/commerce_coordinator/apps/lms/utils.py
+++ b/commerce_coordinator/apps/lms/utils.py
@@ -53,7 +53,7 @@ def get_program_offer(cart_discounts: list, bundle_key: str) -> dict:
     default_program_offer = None
     for cart_discount in cart_discounts:
         cart_discount_key = cart_discount.get("key")
-        bundle_ids_from_predicate = extract_uuids_from_predicate(cart_discount.get("target", {}).get("predicate"))
+        bundle_ids_from_predicate = extract_uuids_from_predicate(cart_discount.get("cartPredicate", ""))
 
         if cart_discount_key == DEFAULT_BUNDLE_DISCOUNT_KEY:
             default_program_offer = cart_discount
@@ -64,8 +64,8 @@ def get_program_offer(cart_discounts: list, bundle_key: str) -> dict:
 
     # If no offer is applied on the program, check if it is also excluded from default 10% offer
     if not program_offer and default_program_offer:
-        predicate = default_program_offer.get("target", {}).get("predicate")
-        excluded_bundle_ids_for_default_discount = extract_uuids_from_predicate(predicate)
+        cart_predicate = default_program_offer.get("cartPredicate", "")
+        excluded_bundle_ids_for_default_discount = extract_uuids_from_predicate(cart_predicate)
 
         if bundle_key in excluded_bundle_ids_for_default_discount:
             return None


### PR DESCRIPTION
- Get the updated key cartPredicate from the cart discount object 
- Get all active cart discounts

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
