### PR TITLE
feat: format price for different currencies in email

### DIFF
--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -217,6 +217,11 @@ def fulfill_order_placed_message_signal_task(
         product_information = extract_ct_product_information_for_braze_canvas(item)
         canvas_entry_properties["products"].append(product_information)
 
+    is_mobile_order = False
+    if hasattr(order, 'custom') and hasattr(order.custom, 'fields'):
+        is_mobile_order = order.custom.fields.get(TwoUKeys.ORDER_MOBILE_ORDER, False)
+    canvas_entry_properties.update({'is_mobile_order': is_mobile_order})
+
     cache_key = safe_key(key=order_id, key_prefix='send_order_confirmation_email', version='1')
 
     cache_entry = TieredCache.get_cached_response(cache_key)

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -220,7 +220,9 @@ def fulfill_order_placed_message_signal_task(
     is_mobile_order = False
     if hasattr(order, 'custom') and hasattr(order.custom, 'fields'):
         is_mobile_order = order.custom.fields.get(TwoUKeys.ORDER_MOBILE_ORDER, False)
-    canvas_entry_properties.update({'is_mobile_order': is_mobile_order})
+    is_enrollment_code_order = get_edx_psp_payment_id(order) is None and order.total_price.cent_amount == 0
+
+    canvas_entry_properties.update({'hide_receipt_cta': is_mobile_order or is_enrollment_code_order})
 
     cache_key = safe_key(key=order_id, key_prefix='send_order_confirmation_email', version='1')
 

--- a/commerce_coordinator/apps/commercetools/utils.py
+++ b/commerce_coordinator/apps/commercetools/utils.py
@@ -2,10 +2,10 @@
 Helpers for the commercetools app.
 """
 
-from decimal import Decimal
 import hashlib
 import logging
 import re
+from decimal import Decimal
 
 from babel.numbers import format_currency, get_currency_symbol
 from braze.client import BrazeClient
@@ -64,7 +64,9 @@ def send_order_confirmation_email(
     lms_user_id, lms_user_email, canvas_entry_properties
 ):
     """ Sends order confirmation email via Braze. """
-    recipients = [{"external_user_id": 5264635}]
+    recipients = [{"external_user_id": lms_user_id, "attributes": {
+        "email": lms_user_email,
+    }}]
     canvas_id = settings.BRAZE_CT_ORDER_CONFIRMATION_CANVAS_ID
 
     try:
@@ -121,7 +123,7 @@ def format_amount_for_braze_canvas(cent_amount, currency_code):
             currency_code=currency_code
         )
         return format_iso_like_currency_spacing(localized_price, currency_code)
-    except Exception as e:
+    except (ValueError, TypeError) as e:
         # Log or handle the exception as needed
         print(f"[format_amount_for_braze_canvas] Failed to format currency: {currency_code}, "
               f"value: {cent_amount}, error: {e}")

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,6 +7,7 @@ commercetools @ git+https://github.com/edx/commercetools-python-sdk.git@main
 app-store-notifications-v2-validator
 asgiref==3.7.2       # Until we switch to Py 3.10, this has some serius issues with debuggers.
 attrs
+babel
 celery
 celery[redis]
 currencies           # Currency Formatting

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,6 +24,8 @@ asgiref==3.7.2
     #   django-cors-headers
 attrs==25.3.0
     # via -r requirements/base.in
+babel==2.17.0
+    # via -r requirements/base.in
 backoff==2.2.1
     # via segment-analytics-python
 billiard==4.2.1

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,6 +1,3 @@
-
-
-
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,3 +1,6 @@
+
+
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -36,6 +36,8 @@ astroid==3.3.10
     #   pylint-celery
 attrs==25.3.0
     # via -r requirements/validation.txt
+babel==2.17.0
+    # via -r requirements/validation.txt
 backoff==2.2.1
     # via
     #   -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -42,6 +42,7 @@ attrs==25.3.0
     # via -r requirements/test.txt
 babel==2.17.0
     # via
+    #   -r requirements/test.txt
     #   pydata-sphinx-theme
     #   sphinx
 backoff==2.2.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -31,6 +31,8 @@ asgiref==3.7.2
     #   django-cors-headers
 attrs==25.3.0
     # via -r requirements/base.txt
+babel==2.17.0
+    # via -r requirements/base.txt
 backoff==2.2.1
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -36,6 +36,8 @@ astroid==3.3.10
     #   pylint-celery
 attrs==25.3.0
     # via -r requirements/test.txt
+babel==2.17.0
+    # via -r requirements/test.txt
 backoff==2.2.1
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -35,6 +35,8 @@ astroid==3.3.10
     #   pylint-celery
 attrs==25.3.0
     # via -r requirements/base.txt
+babel==2.17.0
+    # via -r requirements/base.txt
 backoff==2.2.1
     # via
     #   -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -46,6 +46,10 @@ attrs==25.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+babel==2.17.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 backoff==2.2.1
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
Hide receipt button for mobile order 
format external price as price 

in order confirmation email for mobile order

### Mobile Order with PKR currency
![image](https://github.com/user-attachments/assets/216a5f40-e6ae-4999-9a33-43174c3b367e)

### Mobile Order with USD currency (2 fraction digits)
![image](https://github.com/user-attachments/assets/e7dab232-b9e3-48ed-af40-7e7f23017797)

### Mobile Order with JPY currency (0 fraction digits)
![image](https://github.com/user-attachments/assets/ca480e4a-f984-410f-b973-5a23af1c8658)

### Mobile Order with KWD currency (3 fraction digits)
![image](https://github.com/user-attachments/assets/167bb3fb-211a-403c-b88a-ce2a74698867)

### Normal Order with USD currency
![image](https://github.com/user-attachments/assets/49736b86-0e6f-4e75-a552-2cf8f87d924d)

### Enrollment Code Order 100% Off
![image](https://github.com/user-attachments/assets/7ea180cf-a72b-4bfe-9c56-23c1c0a45a71)


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
