### PR TITLE
fix: handle 500 error in user retirement view

### DIFF
--- a/commerce_coordinator/apps/commercetools/pipeline.py
+++ b/commerce_coordinator/apps/commercetools/pipeline.py
@@ -450,6 +450,13 @@ class AnonymizeRetiredUser(PipelineStep):
         ct_api_client = CommercetoolsAPIClient()
         try:
             customer = ct_api_client.get_customer_by_lms_user_id(lms_user_id)
+
+            if not customer:
+                log.info(f"[{tag}] Commercetools Customer not found for LMS user ID: {lms_user_id}")
+                return {
+                    'returned_customer': 'customer_not_found'
+                }
+
             first_name = customer.first_name
             last_name = customer.last_name
             email = customer.email

--- a/commerce_coordinator/apps/commercetools/tests/test_pipeline.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_pipeline.py
@@ -356,6 +356,19 @@ class AnonymizeRetiredUserPipelineTests(TestCase):
         result_data = ret['returned_customer']
         self.assertEqual(result_data, self.update_customer_response)
 
+    @patch(
+        'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient'
+        '.get_customer_by_lms_user_id'
+    )
+    def test_pipeline_customer_not_found(self, mock_customer_by_lms_id):
+        """Ensure pipeline is functioning as expected"""
+
+        pipe = AnonymizeRetiredUser("test_pipe", None)
+        mock_customer_by_lms_id.return_value = None
+        ret = pipe.run_filter(lms_user_id=self.mock_lms_user_id)
+        result_data = ret['returned_customer']
+        self.assertEqual(result_data, 'customer_not_found')
+
 
 class RefundPayPalPaymentTests(TestCase):
     """Tests for RefundPayPalPayment pipeline step"""

--- a/commerce_coordinator/apps/lms/tests/test_views.py
+++ b/commerce_coordinator/apps/lms/tests/test_views.py
@@ -443,6 +443,15 @@ class RetirementViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         mock_filter.assert_called_once_with(127)
 
+    @patch('commerce_coordinator.apps.lms.views.UserRetirementRequested.run_filter')
+    def test_post_with_valid_data_pipeline_return_customer_not_found(self, mock_filter):
+        self.authenticate_user()
+        mock_filter.return_value = {'returned_customer': 'customer_not_found'}
+        response = self.client.post(self.url, self.valid_payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_filter.assert_called_once_with(127)
+
     def test_post_with_invalid_data_fails(self):
         self.authenticate_user()
         response = self.client.post(self.url, self.invalid_payload, format='json')


### PR DESCRIPTION
fixes `AttributeError: 'NoneType' object has no attribute 'first_name'` error

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
