### PR TITLE
fix: redirect credit checkout to legacy ecommerce for course not found

### DIFF
--- a/commerce_coordinator/apps/lms/views.py
+++ b/commerce_coordinator/apps/lms/views.py
@@ -616,7 +616,10 @@ class CreditCheckoutView(APIView):
                 logger.warning(
                     f"{self.get.__qualname__} No credit variant found for course_run_key={course_run_key}"
                 )
-                return HttpResponseBadRequest("Something went wrong.")
+                # TODO: This redirection will be removed as part of the SONIC-1110
+                redirect_url = f"{settings.ECOMMERCE_URL}/credit/checkout/{course_run_key}/"
+                # Redirect to legacy credit checkout if course not found on CT
+                return HttpResponseRedirect(redirect_url)
 
             # Build redirect URL to payment_page_redirect
             payment_path = reverse("lms:payment_page_redirect")


### PR DESCRIPTION
There is a credit course that is available on ecommerce but not on discovery, when teh users try to purchase that course, they can't because its not migrated to CT due to unavailability in discovery. 

So we are temporarily redirecting to legacy ecommerce so that users can purchase it.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
