### PR TITLE
feat: add multi_item_cart eventing

### DIFF
--- a/commerce_coordinator/apps/commercetools/utils.py
+++ b/commerce_coordinator/apps/commercetools/utils.py
@@ -188,6 +188,7 @@ def prepare_segment_event_properties(
             calculate_total_discount_on_order(order, line_item_ids)
         ),
         "products": [],
+        "multi_item_cart_enabled": len(order.line_items) > 1,
     }
 
 

--- a/commerce_coordinator/apps/iap/segment_events.py
+++ b/commerce_coordinator/apps/iap/segment_events.py
@@ -92,6 +92,7 @@ def emit_product_added_event(
     standalone_price: CentPrecisionMoney,
     line_item: LineItem,
     discount_codes: list[dict[str, any]],
+    line_items: list[LineItem],
 ) -> None:
 
     """
@@ -103,6 +104,7 @@ def emit_product_added_event(
         standalone_price (CentPrecisionMoney): Price object for the added product before discounts.
         line_item (LineItem): The product line item that was added to the cart.
         discount_codes (list[dict[str, any]]): List of discount code dictionaries applied to the cart.
+        line_items (list[LineItem]): All line items in the cart to determine multi-item status.
 
     Emits:
         A "Product Added" event with details including:
@@ -110,6 +112,7 @@ def emit_product_added_event(
             - Cart ID and checkout ID
             - Applied coupon (if any)
             - Device context (hardcoded as mobile)
+            - Multi-item cart flag
     """
 
     discount_code = (
@@ -128,7 +131,7 @@ def emit_product_added_event(
         "coupon": discount_code,
         **product_info,
         "is_mobile": True,
-        "multi_item_cart_enabled": False  # Cannot determine cart state without context
+        "multi_item_cart_enabled": len(line_items) > 1
     }
 
     track(

--- a/commerce_coordinator/apps/iap/segment_events.py
+++ b/commerce_coordinator/apps/iap/segment_events.py
@@ -75,7 +75,8 @@ def emit_checkout_started_event(
         "coupon": discount_code,
         "discount": discount_in_dollars,
         "products": products,
-        "is_mobile": True
+        "is_mobile": True,
+        "multi_item_cart_enabled": len(line_items) > 1
     }
 
     track(
@@ -126,7 +127,8 @@ def emit_product_added_event(
         "checkout_id": cart_id,
         "coupon": discount_code,
         **product_info,
-        "is_mobile": True
+        "is_mobile": True,
+        "multi_item_cart_enabled": False  # Cannot determine cart state without context
     }
 
     track(
@@ -166,7 +168,8 @@ def emit_payment_info_entered_event(
         "checkout_id": cart_id,
         "currency": standalone_price.currency_code,
         "payment_method": payment_method,
-        "is_mobile": True
+        "is_mobile": True,
+        "multi_item_cart_enabled": False  # Cannot determine cart state without context
     }
 
     track(
@@ -253,11 +256,80 @@ def emit_order_completed_event(
         "payment_method": payment_method,
         "processor_name": processor_name,
         "products": products,
-        "is_mobile": True
+        "is_mobile": True,
+        "multi_item_cart_enabled": len(line_items) > 1
     }
 
     track(
         lms_user_id=lms_user_id,
         event='Order Completed',
+        properties=event_props
+    )
+
+
+def emit_cart_viewed_event(
+    lms_user_id: int,
+    cart_id: str,
+    standalone_price: CentPrecisionMoney,
+    line_items: list[LineItem],
+    discount_codes: list[DiscountCode],
+    discount_on_line_items: Optional[list[CentPrecisionMoney]],
+    discount_on_total_price: Optional[CentPrecisionMoney] = None
+) -> None:
+
+    """
+    Triggers the Segment v2 ecommerce "Cart Viewed" event with multiple products support.
+
+    Args:
+        lms_user_id (int): ID of the user viewing the cart.
+        cart_id (str): Unique identifier for the shopping cart.
+        standalone_price (CentPrecisionMoney): The total price of the cart before discounts.
+        line_items (list[LineItem]): List of line items in the cart.
+        discount_codes (list[DiscountCode]): List of discount code dictionaries applied to the cart.
+        discount_on_line_items (list[CentPrecisionMoney]): Discounts applied to individual items.
+        discount_on_total_price (Optional[CentPrecisionMoney]): Discount applied to the entire cart.
+
+    Emits:
+        A Segment v2 ecommerce "Cart Viewed" event with details such as:
+            - cart_id
+            - currency and total value
+            - applied coupon and total discount
+            - products array with multiple products support
+            - multi_item_cart_enabled flag
+    """
+    discount_code = (
+        discount_codes[-1]["code"]
+        if discount_codes and "code" in discount_codes[-1]
+        else None
+    )
+
+    discount_in_dollars = cents_to_dollars(
+        sum_money(discount_on_total_price, discount_on_line_items)
+    )
+
+    # Create products array following Segment v2 ecommerce specification
+    products = []
+    for position, item in enumerate(line_items, 1):
+        product_info = get_product_from_line_item(item, standalone_price)
+        # Add position for Segment v2 ecommerce specification
+        product_info["position"] = position
+        products.append(product_info)
+
+    event_props = {
+        "track_plan_id": 20,
+        "trigger_source": 'server-side',
+        "cart_id": cart_id,
+        "currency": standalone_price.currency_code,
+        "value": cents_to_dollars(standalone_price),
+        "coupon": discount_code,
+        "discount": discount_in_dollars,
+        "products": products,
+        "is_mobile": True,
+        "multi_item_cart_enabled": len(line_items) > 1
+    }
+
+    track(
+        lms_user_id=lms_user_id,
+        event='Cart Viewed',
         properties=event_props
     )

--- a/commerce_coordinator/apps/iap/tests/test_segment_events.py
+++ b/commerce_coordinator/apps/iap/tests/test_segment_events.py
@@ -10,7 +10,6 @@ import pytest
 from commercetools.platform.models import CentPrecisionMoney, LineItem, PaymentMethodInfo, TaxedPrice
 
 from commerce_coordinator.apps.iap.segment_events import (
-    emit_cart_viewed_event,
     emit_checkout_started_event,
     emit_order_completed_event,
     emit_payment_info_entered_event,
@@ -249,7 +248,8 @@ def test_emit_payment_info_entered_event(
         lms_user_id=1,
         cart_id="cart123",
         standalone_price=mock_price,
-        payment_method=mock_payment_method
+        payment_method=mock_payment_method,
+        line_items=[mock_line_item]
     )
 
     mock_track.assert_called_once()
@@ -345,73 +345,3 @@ def test_emit_order_completed_event(
     assert props["processor_name"] == "android iap"
     assert props["products"][0]["product_id"] == "course-v1:edX+DemoX+Demo_Course"
     assert props["is_mobile"] is True
-
-
-@patch('commerce_coordinator.apps.iap.segment_events.track')
-def test_emit_cart_viewed_event(mock_track, mock_price, mock_line_item):
-    """
-    Test that the Cart Viewed event is emitted with correct properties and multiple products support
-    """
-    emit_cart_viewed_event(
-        lms_user_id=1,
-        cart_id="cart123",
-        standalone_price=mock_price,
-        line_items=[mock_line_item],
-        discount_codes=[],
-        discount_on_line_items=[],
-        discount_on_total_price=None
-    )
-
-    mock_track.assert_called_once()
-    _, kwargs = mock_track.call_args
-
-    assert kwargs["lms_user_id"] == 1
-    assert kwargs["event"] == "Cart Viewed"
-    props = kwargs["properties"]
-    assert props["cart_id"] == "cart123"
-    assert props["currency"] == "USD"
-    assert props["value"] == 100.0
-    assert props["coupon"] is None
-    assert props["discount"] is None
-    assert props["products"][0]["product_id"] == "course-v1:edX+DemoX+Demo_Course"
-    assert props["products"][0]["position"] == 1
-    assert props["multi_item_cart_enabled"] is False  # Cannot determine cart state without context
-
-
-@patch('commerce_coordinator.apps.iap.segment_events.track')
-def test_emit_cart_viewed_event_multiple_products(mock_track, mock_price, mock_line_item):
-    """
-    Test that the Cart Viewed event handles multiple products correctly
-    """
-    # Create a second line item
-    mock_line_item_2 = MagicMock()
-    mock_line_item_2.name = {"en-US": "Second Course"}
-    mock_line_item_2.variant.sku = "demo-sku-2"
-    mock_line_item_2.variant.attributes = []
-    mock_line_item_2.price.value = mock_price
-    mock_line_item_2.quantity = 1
-    mock_line_item_2.id = "line-item-2"
-
-    emit_cart_viewed_event(
-        lms_user_id=1,
-        cart_id="cart123",
-        standalone_price=mock_price,
-        line_items=[mock_line_item, mock_line_item_2],
-        discount_codes=[],
-        discount_on_line_items=[],
-        discount_on_total_price=None
-    )
-
-    mock_track.assert_called_once()
-    _, kwargs = mock_track.call_args
-
-    assert kwargs["lms_user_id"] == 1
-    assert kwargs["event"] == "Cart Viewed"
-    props = kwargs["properties"]
-    assert props["cart_id"] == "cart123"
-    assert len(props["products"]) == 2
-    assert props["products"][0]["position"] == 1
-    assert props["products"][1]["position"] == 2
-    assert props["multi_item_cart_enabled"] is True  # Multiple items cart
-
-

--- a/commerce_coordinator/apps/iap/tests/test_segment_events.py
+++ b/commerce_coordinator/apps/iap/tests/test_segment_events.py
@@ -139,10 +139,13 @@ def test_emit_checkout_started_event(
 
 @patch("commerce_coordinator.apps.iap.segment_events.track")
 @patch("commerce_coordinator.apps.iap.segment_events.get_product_from_line_item")
-def test_emit_product_added_event(
+def test_emit_product_added_event_single_item(
     mock_get_product_from_line_item,
-    mock_track
+    mock_track,
+    mock_price,
+    mock_line_item
 ):
+    """Test Product Added event with single item cart"""
 
     mock_get_product_from_line_item.return_value = {
         "product_id": "course-v1:edX+DemoX+Demo_Course",
@@ -163,7 +166,8 @@ def test_emit_product_added_event(
         cart_id="cart123",
         standalone_price=mock_price,
         line_item=mock_line_item,
-        discount_codes=[]
+        discount_codes=[],
+        line_items=[mock_line_item]  # Single item cart
     )
 
     mock_track.assert_called_once()
@@ -177,6 +181,61 @@ def test_emit_product_added_event(
     assert props["coupon"] is None
     assert props["product_id"] == "course-v1:edX+DemoX+Demo_Course"
     assert props["is_mobile"] is True
+    assert props["multi_item_cart_enabled"] is False
+
+
+@patch("commerce_coordinator.apps.iap.segment_events.track")
+@patch("commerce_coordinator.apps.iap.segment_events.get_product_from_line_item")
+def test_emit_product_added_event_multi_item(
+    mock_get_product_from_line_item,
+    mock_track,
+    mock_price,
+    mock_line_item
+):
+    """Test Product Added event with multi-item cart"""
+
+    mock_get_product_from_line_item.return_value = {
+        "product_id": "course-v1:edX+DemoX+Demo_Course",
+        "sku": "demo-sku",
+        "name": {"en-US": "Demo Course"},
+        "price": 100.0,
+        "quantity": 1,
+        "category": "business",
+        "url": "https://example.com/course",
+        "lob": "edx",
+        "image_url": "https://example.com/image.jpg",
+        "brand": "edX",
+        "product_type": "edX Course"
+    }
+
+    # Create a second line item for multi-item cart
+    mock_line_item_2 = MagicMock()
+    mock_line_item_2.name = {"en-US": "Second Course"}
+    mock_line_item_2.variant.sku = "demo-sku-2"
+    mock_line_item_2.quantity = 1
+    mock_line_item_2.product_key = "test-sku-2"
+
+    emit_product_added_event(
+        lms_user_id=1,
+        cart_id="cart123",
+        standalone_price=mock_price,
+        line_item=mock_line_item,
+        discount_codes=[],
+        line_items=[mock_line_item, mock_line_item_2]  # Multi-item cart
+    )
+
+    mock_track.assert_called_once()
+    _, kwargs = mock_track.call_args
+
+    assert kwargs["lms_user_id"] == 1
+    assert kwargs["event"] == "Product Added"
+    props = kwargs["properties"]
+    assert props["cart_id"] == "cart123"
+    assert props["checkout_id"] == "cart123"
+    assert props["coupon"] is None
+    assert props["product_id"] == "course-v1:edX+DemoX+Demo_Course"
+    assert props["is_mobile"] is True
+    assert props["multi_item_cart_enabled"] is True
 
 
 @patch("commerce_coordinator.apps.iap.segment_events.track")

--- a/commerce_coordinator/apps/iap/views.py
+++ b/commerce_coordinator/apps/iap/views.py
@@ -158,6 +158,7 @@ class MobileCreateOrderView(APIView):
                     standalone_price=standalone_price,
                     line_item=item,
                     discount_codes=cart.discount_codes,
+                    line_items=cart.line_items,
                 )
 
             # Use existing payment if provided, otherwise create new one

--- a/commerce_coordinator/apps/iap/views.py
+++ b/commerce_coordinator/apps/iap/views.py
@@ -180,6 +180,7 @@ class MobileCreateOrderView(APIView):
                 cart_id=cart.id,
                 standalone_price=standalone_price,
                 payment_method=payment.payment_method_info.method,
+                line_items=cart.line_items,
             )
 
             region_code = payment_info["response"].get("region_code")


### PR DESCRIPTION
[EDUN-6007 ](https://redventures.atlassian.net/browse/EDUN-6007)

description: 
All events in systems need to have the multi_item_cart_enabled boolean added

For Standard Segment events, make sure they can handle multiple products in payload

For Non-standard custom events, verify they do not break, but no need to update them

