### PR TITLE
fix: pin setuptools in constraints

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,3 +15,4 @@
 Django<4.3
 marshmallow == 3.26.1  #TODO: Remove constraint when commercetools SDK supports marshmallow v4.0+.
 celery[redis] == 5.4.0
+setuptools<82  # v82 includes breaking change by removing pkg_resources

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -2,5 +2,5 @@
 -c constraints.txt
 
 pip
-setuptools<82
+setuptools
 wheel


### PR DESCRIPTION
Add setuptools constraint for all requirements files (breaking change in v82, see https://setuptools.pypa.io/en/latest/history.html#v82-0-0)

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
