### PR TITLE
fix: send revoke line items signal from order returned task

### DIFF
--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 fulfill_order_placed_send_enroll_in_course_signal = CoordinatorSignal()
 fulfill_order_placed_send_entitlement_signal = CoordinatorSignal()
+fulfill_order_returned_send_revoke_line_items_signal = CoordinatorSignal()
 
 
 @log_receiver(logger)

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -41,7 +41,8 @@ from commerce_coordinator.apps.commercetools.serializers import (
 )
 from commerce_coordinator.apps.commercetools.signals import (
     fulfill_order_placed_send_enroll_in_course_signal,
-    fulfill_order_placed_send_entitlement_signal
+    fulfill_order_placed_send_entitlement_signal,
+    fulfill_order_returned_send_revoke_line_items_signal
 )
 from commerce_coordinator.apps.commercetools.utils import (
     convert_ct_cent_amount_to_localized_price,
@@ -457,6 +458,13 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
             order=order,
             return_line_item_return_ids=return_line_item_return_ids,
         )
+
+    # revoke line items on successful return
+    fulfill_order_returned_send_revoke_line_items_signal.send_robust(
+        sender=fulfill_order_returned_signal_task,
+        order_id=order_id,
+        return_items=return_items,
+    )
 
     logger.info(f'[CT-{tag}] Finished return for order: {order_id}, line item: {return_line_item_ids}, '
                 f'message id: {message_id}')

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -443,6 +443,13 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
                         event='Order Refunded',
                         properties=segment_event_properties
                     )
+
+            # revoke line items
+            fulfill_order_returned_send_revoke_line_items_signal.send_robust(
+                sender=fulfill_order_returned_signal_task,
+                order_id=order_id,
+                return_items=return_items,
+            )
         else:  # pragma no cover
             logger.info(f'[CT-{tag}] payment {psp_payment_id} not refunded, '
                         f'sending Slack notification, message id: {message_id}')
@@ -458,13 +465,6 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
             order=order,
             return_line_item_return_ids=return_line_item_return_ids,
         )
-
-    # revoke line items on successful return
-    fulfill_order_returned_send_revoke_line_items_signal.send_robust(
-        sender=fulfill_order_returned_signal_task,
-        order_id=order_id,
-        return_items=return_items,
-    )
 
     logger.info(f'[CT-{tag}] Finished return for order: {order_id}, line item: {return_line_item_ids}, '
                 f'message id: {message_id}')

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -452,6 +452,13 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
         super().setUp()
         self.mock = CommercetoolsAPIClientMock()
 
+        revoke_send_patcher = patch(
+            "commerce_coordinator.apps.commercetools.sub_messages.tasks."
+            "fulfill_order_returned_send_revoke_line_items_signal.send_robust",
+        )
+        self.mock_revoke_line_send = revoke_send_patcher.start()
+        self.addCleanup(revoke_send_patcher.stop)
+
         # Force reset nested mocked return object
         order_return = self.mock.order_mock.return_value
         if hasattr(order_return, "custom") and hasattr(order_return.custom, "fields"):
@@ -650,6 +657,15 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
 class FulfillOrderReturnedSignalTaskTests(TestCase):
     """Tests for the fulfill_order_returned_signal_task"""
 
+    def setUp(self):
+        super().setUp()
+        revoke_send_patcher = patch(
+            "commerce_coordinator.apps.commercetools.sub_messages.tasks."
+            "fulfill_order_returned_send_revoke_line_items_signal.send_robust",
+        )
+        self.mock_revoke_line_send = revoke_send_patcher.start()
+        self.addCleanup(revoke_send_patcher.stop)
+
     @staticmethod
     def unpack_for_uut(values):
         """ Unpack the dictionary in the order required for the UUT """
@@ -670,11 +686,17 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         """
         mock_values = _ct_client_init.return_value
         _run_filter_mock.return_value = {'refund_response': 'charge_already_refunded'}
-        ret_val = self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
+        payload = mock_values.example_payload
+        ret_val = self.get_uut()(*self.unpack_for_uut(payload))
 
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
+        self.mock_revoke_line_send.assert_called_once_with(
+            sender=fulfill_order_returned_signal_task,
+            order_id=payload["order_id"],
+            return_items=payload["return_items"],
+        )
 
     def test_order_not_found(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
         """
@@ -686,7 +708,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(CommercetoolsError):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
-        self.assertRaises(CommercetoolsError)
+        self.mock_revoke_line_send.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
 
     def test_customer_not_found(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
@@ -699,6 +721,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(CommercetoolsError):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
+        self.mock_revoke_line_send.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
 
@@ -712,6 +735,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
             ret_val = self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
         self.assertTrue(ret_val)
+        self.mock_revoke_line_send.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
 
@@ -721,11 +745,17 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         """
         mock_values = _ct_client_init.return_value
         _run_filter_mock.return_value = {'refund_response': 'succeeded'}
-        ret_val = self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
+        payload = mock_values.example_payload
+        ret_val = self.get_uut()(*self.unpack_for_uut(payload))
 
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
+        self.mock_revoke_line_send.assert_called_once_with(
+            sender=fulfill_order_returned_signal_task,
+            order_id=payload["order_id"],
+            return_items=payload["return_items"],
+        )
 
     def test_refund_successful_with_segment(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
         """
@@ -737,11 +767,17 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
             'amount_in_cents': 5400,
             'filtered_line_item_ids': ['822d77c4-00a6-4fb9-909b-094ef0b8c4b9'],
         }
-        ret_val = self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
+        payload = mock_values.example_payload
+        ret_val = self.get_uut()(*self.unpack_for_uut(payload))
 
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
+        self.mock_revoke_line_send.assert_called_once_with(
+            sender=fulfill_order_returned_signal_task,
+            order_id=payload["order_id"],
+            return_items=payload["return_items"],
+        )
 
     def test_refund_unsuccessful(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
         """
@@ -752,5 +788,6 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(Exception):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
+        self.mock_revoke_line_send.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)

--- a/commerce_coordinator/apps/commercetools/tests/test_signals.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_signals.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from django.test import override_settings
 
+from commerce_coordinator.apps.commercetools.signals import fulfill_order_returned_send_revoke_line_items_signal
 from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD
 from commerce_coordinator.apps.core.tests.utils import CoordinatorSignalReceiverTestCase
 
@@ -196,7 +197,7 @@ class RevokeMobileOrderTest(CoordinatorSignalReceiverTestCase):
 
 @override_settings(
     CC_SIGNALS={
-        "commerce_coordinator.apps.core.tests.utils.example_signal": [
+        "commerce_coordinator.apps.commercetools.signals.fulfill_order_returned_send_revoke_line_items_signal": [
             "commerce_coordinator.apps.commercetools.signals.revoke_line_items",
         ],
     }
@@ -204,6 +205,8 @@ class RevokeMobileOrderTest(CoordinatorSignalReceiverTestCase):
 @patch("commerce_coordinator.apps.commercetools.signals.revoke_line_items_task")
 class RevokeLineItemsTest(CoordinatorSignalReceiverTestCase):
     """Order return / revoke: enqueue revoke_line_items_task for LMS unenrollment."""
+
+    mock_signal = fulfill_order_returned_send_revoke_line_items_signal
 
     mock_parameters = {
         "order_id": "7506b6f1-8fe2-440d-ac76-4f62dfbd3775",

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -311,6 +311,9 @@ CC_SIGNALS = {
     'commerce_coordinator.apps.commercetools.signals.fulfill_order_placed_send_entitlement_signal': [
         'commerce_coordinator.apps.lms.signal_handlers.fulfill_order_placed_send_entitlement',
     ],
+    'commerce_coordinator.apps.commercetools.signals.fulfill_order_returned_send_revoke_line_items_signal': [
+        'commerce_coordinator.apps.commercetools.signals.revoke_line_items',
+    ],
     'commerce_coordinator.apps.lms.signals.fulfillment_completed_update_ct_line_item_signal': [
         'commerce_coordinator.apps.commercetools.signals.fulfillment_completed_update_ct_line_item',
     ],
@@ -322,7 +325,6 @@ CC_SIGNALS = {
     ],
     'commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch.fulfill_order_returned_signal': [
         'commerce_coordinator.apps.commercetools.sub_messages.signals_delayed.fulfill_order_returned_signal',
-        'commerce_coordinator.apps.commercetools.signals.revoke_line_items',
     ],
     'commerce_coordinator.apps.stripe.signals.payment_refunded_signal': [
         'commerce_coordinator.apps.commercetools.signals.refund_from_stripe',


### PR DESCRIPTION
Revoke line items task is not being triggered from `fulfill_order_returned_signal`. Create a separate signal for the revoke line items task and manually call it from the order returned task once the return is successful.

Internal ticket: https://redventures.atlassian.net/browse/RV2U-473

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
