### PR TITLE
fix: move revoke signal call to return view

### DIFF
--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -41,8 +41,7 @@ from commerce_coordinator.apps.commercetools.serializers import (
 )
 from commerce_coordinator.apps.commercetools.signals import (
     fulfill_order_placed_send_enroll_in_course_signal,
-    fulfill_order_placed_send_entitlement_signal,
-    fulfill_order_returned_send_revoke_line_items_signal
+    fulfill_order_placed_send_entitlement_signal
 )
 from commerce_coordinator.apps.commercetools.utils import (
     convert_ct_cent_amount_to_localized_price,
@@ -443,13 +442,6 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
                         event='Order Refunded',
                         properties=segment_event_properties
                     )
-
-            # revoke line items
-            fulfill_order_returned_send_revoke_line_items_signal.send_robust(
-                sender=fulfill_order_returned_signal_task,
-                order_id=order_id,
-                return_items=return_items,
-            )
         else:  # pragma no cover
             logger.info(f'[CT-{tag}] payment {psp_payment_id} not refunded, '
                         f'sending Slack notification, message id: {message_id}')

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -452,13 +452,6 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
         super().setUp()
         self.mock = CommercetoolsAPIClientMock()
 
-        revoke_send_patcher = patch(
-            "commerce_coordinator.apps.commercetools.sub_messages.tasks."
-            "fulfill_order_returned_send_revoke_line_items_signal.send_robust",
-        )
-        self.mock_revoke_line_send = revoke_send_patcher.start()
-        self.addCleanup(revoke_send_patcher.stop)
-
         # Force reset nested mocked return object
         order_return = self.mock.order_mock.return_value
         if hasattr(order_return, "custom") and hasattr(order_return.custom, "fields"):
@@ -657,15 +650,6 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
 class FulfillOrderReturnedSignalTaskTests(TestCase):
     """Tests for the fulfill_order_returned_signal_task"""
 
-    def setUp(self):
-        super().setUp()
-        revoke_send_patcher = patch(
-            "commerce_coordinator.apps.commercetools.sub_messages.tasks."
-            "fulfill_order_returned_send_revoke_line_items_signal.send_robust",
-        )
-        self.mock_revoke_line_send = revoke_send_patcher.start()
-        self.addCleanup(revoke_send_patcher.stop)
-
     @staticmethod
     def unpack_for_uut(values):
         """ Unpack the dictionary in the order required for the UUT """
@@ -692,11 +676,6 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
-        self.mock_revoke_line_send.assert_called_once_with(
-            sender=fulfill_order_returned_signal_task,
-            order_id=payload["order_id"],
-            return_items=payload["return_items"],
-        )
 
     def test_order_not_found(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
         """
@@ -708,7 +687,6 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(CommercetoolsError):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
-        self.mock_revoke_line_send.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
 
     def test_customer_not_found(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
@@ -721,7 +699,6 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(CommercetoolsError):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
-        self.mock_revoke_line_send.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
 
@@ -735,7 +712,6 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
             ret_val = self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
         self.assertTrue(ret_val)
-        self.mock_revoke_line_send.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
 
@@ -751,11 +727,6 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
-        self.mock_revoke_line_send.assert_called_once_with(
-            sender=fulfill_order_returned_signal_task,
-            order_id=payload["order_id"],
-            return_items=payload["return_items"],
-        )
 
     def test_refund_successful_with_segment(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
         """
@@ -773,11 +744,6 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
-        self.mock_revoke_line_send.assert_called_once_with(
-            sender=fulfill_order_returned_signal_task,
-            order_id=payload["order_id"],
-            return_items=payload["return_items"],
-        )
 
     def test_refund_unsuccessful(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
         """
@@ -788,6 +754,5 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(Exception):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
-        self.mock_revoke_line_send.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)

--- a/commerce_coordinator/apps/commercetools/tests/test_views.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_views.py
@@ -342,9 +342,16 @@ class OrderSanctionedViewTests(APITestCase):
 
 
 @ddt.ddt
-@patch('commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch'
-       '.fulfill_order_returned_signal.send_robust',
-       new_callable=SendRobustSignalMock)
+@patch(
+    'commerce_coordinator.apps.commercetools.views.'
+    'fulfill_order_returned_send_revoke_line_items_signal.send_robust',
+    new_callable=SendRobustSignalMock,
+)
+@patch(
+    'commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch'
+    '.fulfill_order_returned_signal.send_robust',
+    new_callable=SendRobustSignalMock,
+)
 class OrderReturnedViewTests(APITestCase):
     """Tests for order sanctioned view"""
     url = reverse('commercetools:returned')
@@ -379,7 +386,7 @@ class OrderReturnedViewTests(APITestCase):
         'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_customer_by_id',
         new_callable=CTCustomerByIdMock
     )
-    def test_view_returns_ok(self, _mock_customer, _mock_order, _mock_signal):
+    def test_view_returns_ok(self, _mock_customer, _mock_order, _mock_signal, _mock_revoke_signal):
         """Check authorized user requesting sanction receives a HTTP 200 OK."""
 
         # Login
@@ -390,6 +397,8 @@ class OrderReturnedViewTests(APITestCase):
 
         # Check 200 OK
         self.assertEqual(response.status_code, 200)
+        _mock_signal.assert_called_once()
+        _mock_revoke_signal.assert_called_once()
 
     @patch(
         'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_order_by_id',
@@ -399,7 +408,7 @@ class OrderReturnedViewTests(APITestCase):
         'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_customer_by_id',
         new_callable=CTCustomerByIdMock
     )
-    def test_view_returns_expected_error(self, _mock_customer, _mock_order, _mock_signal):
+    def test_view_returns_expected_error(self, _mock_customer, _mock_order, _mock_signal, _mock_revoke_signal):
         """Check an authorized account requesting fulfillment with bad inputs receive an expected error."""
 
         # Login
@@ -417,6 +426,8 @@ class OrderReturnedViewTests(APITestCase):
             'detail': ['This field is required.'],
         }
         self.assertEqual(response.json(), expected_response)
+        _mock_signal.assert_not_called()
+        _mock_revoke_signal.assert_not_called()
 
     @patch(
         'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_order_by_id',
@@ -426,7 +437,7 @@ class OrderReturnedViewTests(APITestCase):
         'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_customer_by_id',
         new_callable=CTCustomerByIdMock
     )
-    def test_view_returns_expected_error_no_order(self, mock_customer, _mock_order, _mock_signal):
+    def test_view_returns_expected_error_no_order(self, mock_customer, _mock_order, _mock_signal, _mock_revoke_signal):
         """Check an authorized account requesting fulfillment unable to get customer receive an expected error."""
         mock_customer.return_value = None
         # Login
@@ -445,7 +456,7 @@ class OrderReturnedViewTests(APITestCase):
         'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_customer_by_id',
         new_callable=CTCustomerByIdMock
     )
-    def test_view_returns_ok_bad_order_state(self, _mock_customer, _mock_order, _mock_signal):
+    def test_view_returns_ok_bad_order_state(self, _mock_customer, _mock_order, _mock_signal, _mock_revoke_signal):
         """Check authorized user requesting sanction receives a HTTP 200 OK."""
 
         # Login
@@ -465,7 +476,7 @@ class OrderReturnedViewTests(APITestCase):
         'commerce_coordinator.apps.commercetools.clients.CommercetoolsAPIClient.get_customer_by_id',
         new_callable=CTCustomerByIdMock
     )
-    def test_view_returns_ok_missing_order_state(self, _mock_customer, _mock_order, _mock_signal):
+    def test_view_returns_ok_missing_order_state(self, _mock_customer, _mock_order, _mock_signal, _mock_revoke_signal):
         """Check authorized with missing order user requesting sanction receives a HTTP 200 OK."""
 
         # Login
@@ -477,7 +488,7 @@ class OrderReturnedViewTests(APITestCase):
         # Check 200 OK
         self.assertEqual(response.status_code, 200)
 
-    def test_unauthorized_user(self, _mock_signal):
+    def test_unauthorized_user(self, _mock_signal, _mock_revoke_signal):
         """Check unauthorized user is forbidden."""
 
         # Login
@@ -488,3 +499,5 @@ class OrderReturnedViewTests(APITestCase):
 
         # Check 403 Forbidden
         self.assertEqual(response.status_code, 403)
+        _mock_signal.assert_not_called()
+        _mock_revoke_signal.assert_not_called()

--- a/commerce_coordinator/apps/commercetools/views.py
+++ b/commerce_coordinator/apps/commercetools/views.py
@@ -15,6 +15,7 @@ from commerce_coordinator.apps.commercetools.serializers import (
     OrderReturnedViewMessageInputSerializer,
     OrderSanctionedViewMessageInputSerializer
 )
+from commerce_coordinator.apps.commercetools.signals import fulfill_order_returned_send_revoke_line_items_signal
 from commerce_coordinator.apps.commercetools.sub_messages.signals_dispatch import (
     fulfill_order_placed_message_signal,
     fulfill_order_returned_signal,
@@ -149,6 +150,13 @@ class OrderReturnedView(SingleInvocationAPIView):
             order_id=order_id,
             return_items=return_items,
             message_id=message_id
+        )
+
+        # revoke line items
+        fulfill_order_returned_send_revoke_line_items_signal.send_robust(
+            sender=self,
+            order_id=order_id,
+            return_items=return_items,
         )
 
         return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
Move revoke line items signal to`OrderReturnedView` instead of chaining through `fulfill_order_returned_signal_task`

Internal ticket: https://redventures.atlassian.net/browse/RV2U-473

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
