### PR TITLE
fix: call revoke_line_items_task directly instead of via signal

### DIFF
--- a/commerce_coordinator/apps/commercetools/signals.py
+++ b/commerce_coordinator/apps/commercetools/signals.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 fulfill_order_placed_send_enroll_in_course_signal = CoordinatorSignal()
 fulfill_order_placed_send_entitlement_signal = CoordinatorSignal()
-fulfill_order_returned_send_revoke_line_items_signal = CoordinatorSignal()
 
 
 @log_receiver(logger)

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -41,7 +41,7 @@ from commerce_coordinator.apps.commercetools.serializers import (
 )
 from commerce_coordinator.apps.commercetools.signals import (
     fulfill_order_placed_send_enroll_in_course_signal,
-    fulfill_order_placed_send_entitlement_signal,
+    fulfill_order_placed_send_entitlement_signal
 )
 from commerce_coordinator.apps.commercetools.tasks import revoke_line_items_task
 from commerce_coordinator.apps.commercetools.utils import (

--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -42,8 +42,8 @@ from commerce_coordinator.apps.commercetools.serializers import (
 from commerce_coordinator.apps.commercetools.signals import (
     fulfill_order_placed_send_enroll_in_course_signal,
     fulfill_order_placed_send_entitlement_signal,
-    fulfill_order_returned_send_revoke_line_items_signal
 )
+from commerce_coordinator.apps.commercetools.tasks import revoke_line_items_task
 from commerce_coordinator.apps.commercetools.utils import (
     convert_ct_cent_amount_to_localized_price,
     extract_ct_order_information_for_braze_canvas,
@@ -445,8 +445,7 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
                     )
 
             # revoke line items
-            fulfill_order_returned_send_revoke_line_items_signal.send_robust(
-                sender=fulfill_order_returned_signal_task,
+            revoke_line_items_task.delay(
                 order_id=order_id,
                 return_items=return_items,
             )

--- a/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
+++ b/commerce_coordinator/apps/commercetools/tests/sub_messages/test_tasks.py
@@ -452,12 +452,12 @@ class OrderReturnedMessageSignalTaskTests(TestCase):
         super().setUp()
         self.mock = CommercetoolsAPIClientMock()
 
-        revoke_send_patcher = patch(
+        revoke_task_patcher = patch(
             "commerce_coordinator.apps.commercetools.sub_messages.tasks."
-            "fulfill_order_returned_send_revoke_line_items_signal.send_robust",
+            "revoke_line_items_task",
         )
-        self.mock_revoke_line_send = revoke_send_patcher.start()
-        self.addCleanup(revoke_send_patcher.stop)
+        self.mock_revoke_line_task = revoke_task_patcher.start()
+        self.addCleanup(revoke_task_patcher.stop)
 
         # Force reset nested mocked return object
         order_return = self.mock.order_mock.return_value
@@ -659,12 +659,12 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        revoke_send_patcher = patch(
+        revoke_task_patcher = patch(
             "commerce_coordinator.apps.commercetools.sub_messages.tasks."
-            "fulfill_order_returned_send_revoke_line_items_signal.send_robust",
+            "revoke_line_items_task",
         )
-        self.mock_revoke_line_send = revoke_send_patcher.start()
-        self.addCleanup(revoke_send_patcher.stop)
+        self.mock_revoke_line_task = revoke_task_patcher.start()
+        self.addCleanup(revoke_task_patcher.stop)
 
     @staticmethod
     def unpack_for_uut(values):
@@ -692,8 +692,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
-        self.mock_revoke_line_send.assert_called_once_with(
-            sender=fulfill_order_returned_signal_task,
+        self.mock_revoke_line_task.delay.assert_called_once_with(
             order_id=payload["order_id"],
             return_items=payload["return_items"],
         )
@@ -708,7 +707,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(CommercetoolsError):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
-        self.mock_revoke_line_send.assert_not_called()
+        self.mock_revoke_line_task.delay.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
 
     def test_customer_not_found(self, _ct_client_init: CommercetoolsAPIClientMock, _run_filter_mock):
@@ -721,7 +720,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(CommercetoolsError):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
-        self.mock_revoke_line_send.assert_not_called()
+        self.mock_revoke_line_task.delay.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
 
@@ -735,7 +734,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
             ret_val = self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
         self.assertTrue(ret_val)
-        self.mock_revoke_line_send.assert_not_called()
+        self.mock_revoke_line_task.delay.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
 
@@ -751,8 +750,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
-        self.mock_revoke_line_send.assert_called_once_with(
-            sender=fulfill_order_returned_signal_task,
+        self.mock_revoke_line_task.delay.assert_called_once_with(
             order_id=payload["order_id"],
             return_items=payload["return_items"],
         )
@@ -773,8 +771,7 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         self.assertTrue(ret_val)
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)
-        self.mock_revoke_line_send.assert_called_once_with(
-            sender=fulfill_order_returned_signal_task,
+        self.mock_revoke_line_task.delay.assert_called_once_with(
             order_id=payload["order_id"],
             return_items=payload["return_items"],
         )
@@ -788,6 +785,6 @@ class FulfillOrderReturnedSignalTaskTests(TestCase):
         with self.assertRaises(Exception):
             self.get_uut()(*self.unpack_for_uut(mock_values.example_payload))
 
-        self.mock_revoke_line_send.assert_not_called()
+        self.mock_revoke_line_task.delay.assert_not_called()
         mock_values.order_mock.assert_called_once_with(mock_values.order_id)
         mock_values.customer_mock.assert_called_once_with(mock_values.customer_id)

--- a/commerce_coordinator/apps/commercetools/tests/test_signals.py
+++ b/commerce_coordinator/apps/commercetools/tests/test_signals.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 from django.test import override_settings
 
-from commerce_coordinator.apps.commercetools.signals import fulfill_order_returned_send_revoke_line_items_signal
 from commerce_coordinator.apps.commercetools.tests.constants import EXAMPLE_RETURNED_ORDER_STRIPE_SIGNAL_PAYLOAD
 from commerce_coordinator.apps.core.tests.utils import CoordinatorSignalReceiverTestCase
 
@@ -197,7 +196,7 @@ class RevokeMobileOrderTest(CoordinatorSignalReceiverTestCase):
 
 @override_settings(
     CC_SIGNALS={
-        "commerce_coordinator.apps.commercetools.signals.fulfill_order_returned_send_revoke_line_items_signal": [
+        "commerce_coordinator.apps.core.tests.utils.example_signal": [
             "commerce_coordinator.apps.commercetools.signals.revoke_line_items",
         ],
     }
@@ -205,8 +204,6 @@ class RevokeMobileOrderTest(CoordinatorSignalReceiverTestCase):
 @patch("commerce_coordinator.apps.commercetools.signals.revoke_line_items_task")
 class RevokeLineItemsTest(CoordinatorSignalReceiverTestCase):
     """Order return / revoke: enqueue revoke_line_items_task for LMS unenrollment."""
-
-    mock_signal = fulfill_order_returned_send_revoke_line_items_signal
 
     mock_parameters = {
         "order_id": "7506b6f1-8fe2-440d-ac76-4f62dfbd3775",

--- a/commerce_coordinator/settings/base.py
+++ b/commerce_coordinator/settings/base.py
@@ -311,9 +311,6 @@ CC_SIGNALS = {
     'commerce_coordinator.apps.commercetools.signals.fulfill_order_placed_send_entitlement_signal': [
         'commerce_coordinator.apps.lms.signal_handlers.fulfill_order_placed_send_entitlement',
     ],
-    'commerce_coordinator.apps.commercetools.signals.fulfill_order_returned_send_revoke_line_items_signal': [
-        'commerce_coordinator.apps.commercetools.signals.revoke_line_items',
-    ],
     'commerce_coordinator.apps.lms.signals.fulfillment_completed_update_ct_line_item_signal': [
         'commerce_coordinator.apps.commercetools.signals.fulfillment_completed_update_ct_line_item',
     ],

--- a/commerce_coordinator/settings/test.py
+++ b/commerce_coordinator/settings/test.py
@@ -74,6 +74,9 @@ CC_SIGNALS = {
     'commerce_coordinator.apps.commercetools.signals.fulfill_order_placed_send_enroll_in_course_signal': [
         'commerce_coordinator.apps.lms.signal_handlers.fulfill_order_placed_send_enroll_in_course',
     ],
+    'commerce_coordinator.apps.commercetools.signals.fulfill_order_placed_send_entitlement_signal': [
+        'commerce_coordinator.apps.lms.signal_handlers.fulfill_order_placed_send_entitlement',
+    ],
     'commerce_coordinator.apps.lms.signals.fulfillment_completed_update_ct_line_item_signal': [
         'commerce_coordinator.apps.commercetools.signals.fulfillment_completed_update_ct_line_item',
     ],
@@ -88,6 +91,15 @@ CC_SIGNALS = {
     ],
     'commerce_coordinator.apps.stripe.signals.payment_refunded_signal': [
         'commerce_coordinator.apps.commercetools.signals.refund_from_stripe',
+    ],
+    "commerce_coordinator.apps.paypal.signals.payment_refunded_signal": [
+        "commerce_coordinator.apps.commercetools.signals.refund_from_paypal",
+    ],
+    "commerce_coordinator.apps.iap.signals.payment_refunded_signal": [
+        "commerce_coordinator.apps.commercetools.signals.refund_from_mobile",
+    ],
+    "commerce_coordinator.apps.iap.signals.revoke_line_mobile_order_signal": [
+        "commerce_coordinator.apps.commercetools.signals.revoke_line_mobile_order",
     ],
 }
 


### PR DESCRIPTION
`fulfill_order_returned_signal_task` was using `send_robust()` on a Django signal (`fulfill_order_returned_send_revoke_line_items_signal`) to trigger `revoke_line_items_task`. This required the signal to be wired in `CC_SIGNALS`, which could be silently overridden by the production YAML config (`vars().update(config_from_yaml)` in `production.py`). When `send_robust()` has zero connected receivers, it returns an empty list without raising -- so the failure was completely silent.

Changes made across 6 files:

1. `sub_messages/tasks.py` -- Replaced `fulfill_order_returned_send_revoke_line_items_signal.send_robust(...)` with a direct call to `revoke_line_items_task.delay(order_id=order_id, return_items=return_items)`. This eliminates the fragile signal indirection since both the caller and callee are within the same app.
2. `signals.py` -- Removed the `fulfill_order_returned_send_revoke_line_items_signal` definition (no longer needed). The `revoke_line_items` receiver function remains available.
3. `settings/base.py` -- Removed the `fulfill_order_returned_send_revoke_line_items_signal entry` from `CC_SIGNALS`.
4. `tests/sub_messages/test_tasks.py` -- Updated both `OrderReturnedMessageSignalTaskTests` and `FulfillOrderReturnedSignalTaskTests` to mock `revoke_line_items_task` instead of `send_robust`, and assert on `.delay()` calls.
5. `tests/test_signals.py` -- Updated `RevokeLineItemsTest` to use `example_signal` instead of the deleted signal, and removed the unused import.
6. `settings/test.py` -- Added missing signal entries (entitlement, PayPal, IAP/mobile) to keep `CC_SIGNALS` in sync with base.py.

Internal ticket: https://redventures.atlassian.net/browse/RV2U-473