### PR TITLE
fix: update string formatting in fulfill_order_returned_signal_task 

### DIFF
--- a/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
+++ b/commerce_coordinator/apps/commercetools/sub_messages/tasks.py
@@ -337,7 +337,7 @@ def fulfill_order_returned_signal_task(order_id, return_items, message_id):
         return_line_items[line_item_id] = return_id
 
     logger.info(f'[CT-{tag}] Processing return for order: {order_id}, '
-                f'line items: {','.join(return_line_item_return_ids)}, message id: {message_id}')
+                f"line items: {','.join(return_line_item_return_ids)}, message id: {message_id}")
 
     client = CommercetoolsAPIClient()
 


### PR DESCRIPTION
**Fix f-string syntax error in commercetools tasks**
**Problem:**
The translation extraction workflow was failing with a Python syntax error:
**Root Cause:**
tasks.py had an f-string with nested single quotes, causing a parser error:
**Solution:**
Changed the outer f-string quotes from single to double quotes
**jira-link**- https://2u-internal.atlassian.net/browse/AU-2809
