### PR TITLE
feat: enable Gunicorn StatsD metrics for Datadog

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,3 +14,4 @@ omit =
     */templates/*
     commerce_coordinator/celery.py
     commerce_coordinator/apps/core/tasks.py
+    commerce_coordinator/docker_gunicorn_configuration.py

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -11,16 +11,19 @@ bind = "0.0.0.0:8140"
 workers = 2
 
 # StatsD / DogStatsD configuration
-_dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "")
+_dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "").strip()
 
 if _dogstatsd_url:
     # Gunicorn accepts either "HOST:PORT" or "unix://PATH".
-    statsd_host = (
+    _statsd_host = (
         _dogstatsd_url[len("udp://"):]
         if _dogstatsd_url.startswith("udp://")
         else _dogstatsd_url
-    )
-    statsd_prefix = "commerce-coordinator"
+    ).strip()
+
+    if _statsd_host:
+        statsd_host = _statsd_host
+        statsd_prefix = "commerce-coordinator"
 
 
 def pre_request(worker, req):

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -2,12 +2,23 @@
 gunicorn configuration file, see https://docs.gunicorn.org/en/develop/configure.html for more info.
 """
 import multiprocessing  # pylint: disable=unused-import
+import os
 
 preload_app = True
 timeout = 300
 bind = "0.0.0.0:8140"
 
 workers = 2
+
+# StatsD / DogStatsD configuration
+_dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "")
+
+if _dogstatsd_url.startswith("unix://"):
+    statsd_host = _dogstatsd_url.replace("unix://", "", 1)
+else:
+    statsd_host = ("localhost", 8125)
+
+statsd_prefix = "commerce-coordinator"
 
 
 def pre_request(worker, req):

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -22,6 +22,7 @@ if _dogstatsd_url:
     )
     statsd_prefix = "commerce-coordinator"
 
+
 def pre_request(worker, req):
     """Log requests before they are processed."""
     worker.log.info(f"{req.method} {req.path}")

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -13,10 +13,15 @@ workers = 2
 # StatsD / DogStatsD configuration
 _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "")
 
-if _dogstatsd_url.startswith("unix://"):
-    statsd_host = _dogstatsd_url.replace("unix://", "", 1)
+if _dogstatsd_url:
+    # Gunicorn accepts either "HOST:PORT" or "unix://PATH".
+    statsd_host = (
+        _dogstatsd_url[len("udp://"):]
+        if _dogstatsd_url.startswith("udp://")
+        else _dogstatsd_url
+    )
     statsd_prefix = "commerce-coordinator"
-    
+
 def pre_request(worker, req):
     """Log requests before they are processed."""
     worker.log.info(f"{req.method} {req.path}")

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -10,6 +10,7 @@ bind = "0.0.0.0:8140"
 
 workers = 2
 
+
 # StatsD / DogStatsD configuration
 _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "").strip()
 

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -15,12 +15,8 @@ _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "")
 
 if _dogstatsd_url.startswith("unix://"):
     statsd_host = _dogstatsd_url.replace("unix://", "", 1)
-else:
-    statsd_host = ("localhost", 8125)
-
-statsd_prefix = "commerce-coordinator"
-
-
+    statsd_prefix = "commerce-coordinator"
+    
 def pre_request(worker, req):
     """Log requests before they are processed."""
     worker.log.info(f"{req.method} {req.path}")


### PR DESCRIPTION
Enable Gunicorn StatsD metrics emission for Datadog using DD_DOGSTATSD_URL 
with Unix socket support.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
