### PR TITLE
fix: preserve unix DogStatsD URLs in Gunicorn config

### DIFF
--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -17,8 +17,7 @@ _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "").strip()
 if _dogstatsd_url:
     if _dogstatsd_url.startswith("unix://"):
         # Gunicorn accepts unix socket directly as "unix:///path".
-        statsd_host = _dogstatsd_url
-        statsd_prefix = "commerce-coordinator"
+        _statsd_host = _dogstatsd_url if _dogstatsd_url != "unix://" else ""
     else:
         # Strip "udp://" when present; Gunicorn expects plain "HOST:PORT".
         _statsd_host = (
@@ -27,9 +26,9 @@ if _dogstatsd_url:
             else _dogstatsd_url
         ).strip()
 
-        if _statsd_host:
-            statsd_host = _statsd_host
-            statsd_prefix = "commerce-coordinator"
+    if _statsd_host:
+        statsd_host = _statsd_host
+        statsd_prefix = "commerce-coordinator"
 
 
 def pre_request(worker, req):

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -15,16 +15,21 @@ workers = 2
 _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "").strip()
 
 if _dogstatsd_url:
-    # Gunicorn accepts either "HOST:PORT" or "unix://PATH".
-    _statsd_host = (
-        _dogstatsd_url[len("udp://"):]
-        if _dogstatsd_url.startswith("udp://")
-        else _dogstatsd_url
-    ).strip()
-
-    if _statsd_host:
-        statsd_host = _statsd_host
+    if _dogstatsd_url.startswith("unix://"):
+        # Gunicorn accepts unix socket directly as "unix:///path".
+        statsd_host = _dogstatsd_url
         statsd_prefix = "commerce-coordinator"
+    else:
+        # Strip "udp://" when present; Gunicorn expects plain "HOST:PORT".
+        _statsd_host = (
+            _dogstatsd_url[len("udp://"):]
+            if _dogstatsd_url.startswith("udp://")
+            else _dogstatsd_url
+        ).strip()
+
+        if _statsd_host:
+            statsd_host = _statsd_host
+            statsd_prefix = "commerce-coordinator"
 
 
 def pre_request(worker, req):


### PR DESCRIPTION
Finishes GSRE-3388

Updates Gunicorn StatsD configuration to preserve unix:// DogStatsD URLs.This prevents invalid socket configuration when DD_DOGSTATSD_URL is set to a Unix socket path and should resolve StatsD transport errors caused by the previous parsing logic

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
