### PR TITLE
fix: strips URI scheme prefixes from DD_DOGSTATSD_URL

### DIFF
--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -1,9 +1,9 @@
 """
 gunicorn configuration file, see https://docs.gunicorn.org/en/develop/configure.html for more info.
 """
-import logging
 import multiprocessing  # pylint: disable=unused-import
 import os
+import logging
 
 # Use the specific gunicorn error logger
 logger = logging.getLogger("gunicorn.error")
@@ -16,35 +16,33 @@ workers = 2
 
 
 # StatsD / DogStatsD configuration
+# Gunicorn's statsd_host validator (validate_statsd_address) accepts:
+#   "HOST:PORT"     -> Gunicorn parses into (host, port) tuple -> AF_INET UDP
+#   "unix://PATH"   -> Gunicorn parses into a bare string path -> AF_UNIX SOCK_DGRAM
 _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "").strip()
-statsd_host = None
 
 if _dogstatsd_url:
-    # 1. Handle Unix Domain Sockets (requires 'unix:' or 'unixpack:' prefix for Gunicorn)
-    if _dogstatsd_url.startswith("unix://"):
-        path = _dogstatsd_url[len("unix://"):]
-        if path:
-            statsd_host = f"unix:{path}"
-
-    elif _dogstatsd_url.startswith("unixpack://"):
-        path = _dogstatsd_url[len("unixpack://"):]
-        if path:
-            statsd_host = f"unixpack:{path}"
-
-    # 2. Handle UDP or standard HOST:PORT (Gunicorn expects plain "HOST:PORT")
-    elif _dogstatsd_url.startswith("udp://"):
-        statsd_host = _dogstatsd_url[len("udp://"):]
-
+    if _dogstatsd_url.startswith(("unix://", "unixgram://")):
+        # Normalize unixgram:// -> unix:// (Gunicorn's validator expects unix://)
+        _socket_path = _dogstatsd_url.split("://", 1)[1]
+        if _socket_path:
+            # Pass as a string; Gunicorn validator detects this and sets address_family = AF_UNIX
+            statsd_host = f"unix://{_socket_path}"
+            statsd_prefix = "commerce-coordinator"
+            logger.info("Configured statsd_host as UDS: %s", statsd_host)
     else:
-        statsd_host = _dogstatsd_url
+        # Strip udp:// if present; pass plain HOST:PORT string to Gunicorn
+        _statsd_host = (
+            _dogstatsd_url[len("udp://"):]
+            if _dogstatsd_url.startswith("udp://")
+            else _dogstatsd_url
+        ).strip()
 
-    if statsd_host:
-        statsd_prefix = "commerce-coordinator"
-
-        # Log parsed statsd host on startup for verification using gunicorn.error logger
-        logger.info("Configured statsd_host=%s", statsd_host)
-    else:
-        logger.info("DogStatsD URL provided but empty, skipping configuration.")
+        if _statsd_host:
+            # Pass as a string; Gunicorn validator detects host:port and converts to (host, port) tuple
+            statsd_host = _statsd_host
+            statsd_prefix = "commerce-coordinator"
+            logger.info("Configured statsd_host as UDP: %s", statsd_host)
 
 
 def pre_request(worker, req):

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -3,10 +3,6 @@ gunicorn configuration file, see https://docs.gunicorn.org/en/develop/configure.
 """
 import multiprocessing  # pylint: disable=unused-import
 import os
-import logging
-
-# Use the specific gunicorn error logger
-logger = logging.getLogger("gunicorn.error")
 
 preload_app = True
 timeout = 300
@@ -16,7 +12,7 @@ workers = 2
 
 
 # StatsD / DogStatsD configuration
-# Gunicorn's statsd_host validator (validate_statsd_address) accepts:
+# Gunicorn's statsd_host validator (validate_statsd_address) accepts a STRING:
 #   "HOST:PORT"     -> Gunicorn parses into (host, port) tuple -> AF_INET UDP
 #   "unix://PATH"   -> Gunicorn parses into a bare string path -> AF_UNIX SOCK_DGRAM
 _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "").strip()
@@ -25,11 +21,9 @@ if _dogstatsd_url:
     if _dogstatsd_url.startswith(("unix://", "unixgram://")):
         # Normalize unixgram:// -> unix:// (Gunicorn's validator expects unix://)
         _socket_path = _dogstatsd_url.split("://", 1)[1]
-        if _socket_path:
-            # Pass as a string; Gunicorn validator detects this and sets address_family = AF_UNIX
+        if _socket_path:  # guard against bare "unix://" with no path
             statsd_host = f"unix://{_socket_path}"
             statsd_prefix = "commerce-coordinator"
-            logger.info("Configured statsd_host as UDS: %s", statsd_host)
     else:
         # Strip udp:// if present; pass plain HOST:PORT string to Gunicorn
         _statsd_host = (
@@ -39,10 +33,8 @@ if _dogstatsd_url:
         ).strip()
 
         if _statsd_host:
-            # Pass as a string; Gunicorn validator detects host:port and converts to (host, port) tuple
             statsd_host = _statsd_host
             statsd_prefix = "commerce-coordinator"
-            logger.info("Configured statsd_host as UDP: %s", statsd_host)
 
 
 def pre_request(worker, req):

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -1,8 +1,12 @@
 """
 gunicorn configuration file, see https://docs.gunicorn.org/en/develop/configure.html for more info.
 """
+import logging
 import multiprocessing  # pylint: disable=unused-import
 import os
+
+
+logger = logging.getLogger(__name__)
 
 preload_app = True
 timeout = 300
@@ -15,20 +19,22 @@ workers = 2
 _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "").strip()
 
 if _dogstatsd_url:
+    # Strip protocol schemes so Gunicorn receives the raw file path or HOST:PORT
     if _dogstatsd_url.startswith("unix://"):
-        # Gunicorn accepts unix socket directly as "unix:///path".
-        _statsd_host = _dogstatsd_url if _dogstatsd_url != "unix://" else ""
+        _statsd_host = _dogstatsd_url[len("unix://"):]
+    elif _dogstatsd_url.startswith("unixpack://"):
+        _statsd_host = _dogstatsd_url[len("unixpack://"):]
+    elif _dogstatsd_url.startswith("udp://"):
+        _statsd_host = _dogstatsd_url[len("udp://"):]
     else:
-        # Strip "udp://" when present; Gunicorn expects plain "HOST:PORT".
-        _statsd_host = (
-            _dogstatsd_url[len("udp://"):]
-            if _dogstatsd_url.startswith("udp://")
-            else _dogstatsd_url
-        ).strip()
+        _statsd_host = _dogstatsd_url
 
     if _statsd_host:
         statsd_host = _statsd_host
         statsd_prefix = "commerce-coordinator"
+
+        # Log parsed statsd host on startup for verification
+        logger.info("Configured statsd_host=%s", statsd_host)
 
 
 def pre_request(worker, req):

--- a/commerce_coordinator/docker_gunicorn_configuration.py
+++ b/commerce_coordinator/docker_gunicorn_configuration.py
@@ -5,8 +5,8 @@ import logging
 import multiprocessing  # pylint: disable=unused-import
 import os
 
-
-logger = logging.getLogger(__name__)
+# Use the specific gunicorn error logger
+logger = logging.getLogger("gunicorn.error")
 
 preload_app = True
 timeout = 300
@@ -17,24 +17,34 @@ workers = 2
 
 # StatsD / DogStatsD configuration
 _dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL", "").strip()
+statsd_host = None
 
 if _dogstatsd_url:
-    # Strip protocol schemes so Gunicorn receives the raw file path or HOST:PORT
+    # 1. Handle Unix Domain Sockets (requires 'unix:' or 'unixpack:' prefix for Gunicorn)
     if _dogstatsd_url.startswith("unix://"):
-        _statsd_host = _dogstatsd_url[len("unix://"):]
-    elif _dogstatsd_url.startswith("unixpack://"):
-        _statsd_host = _dogstatsd_url[len("unixpack://"):]
-    elif _dogstatsd_url.startswith("udp://"):
-        _statsd_host = _dogstatsd_url[len("udp://"):]
-    else:
-        _statsd_host = _dogstatsd_url
+        path = _dogstatsd_url[len("unix://"):]
+        if path:
+            statsd_host = f"unix:{path}"
 
-    if _statsd_host:
-        statsd_host = _statsd_host
+    elif _dogstatsd_url.startswith("unixpack://"):
+        path = _dogstatsd_url[len("unixpack://"):]
+        if path:
+            statsd_host = f"unixpack:{path}"
+
+    # 2. Handle UDP or standard HOST:PORT (Gunicorn expects plain "HOST:PORT")
+    elif _dogstatsd_url.startswith("udp://"):
+        statsd_host = _dogstatsd_url[len("udp://"):]
+
+    else:
+        statsd_host = _dogstatsd_url
+
+    if statsd_host:
         statsd_prefix = "commerce-coordinator"
 
-        # Log parsed statsd host on startup for verification
+        # Log parsed statsd host on startup for verification using gunicorn.error logger
         logger.info("Configured statsd_host=%s", statsd_host)
+    else:
+        logger.info("DogStatsD URL provided but empty, skipping configuration.")
 
 
 def pre_request(worker, req):


### PR DESCRIPTION
Fixes metrics error by stripping protocol prefixes (unix://) from DD_DOGSTATSD_URL.


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Post-merge:**
- [ ] [Backported](https://openedx.atlassian.net/wiki/spaces/COMM/pages/2065367719/Making+a+pull+request+for+a+named+release) to latest and next named releases
